### PR TITLE
Default Project Styles

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,6 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
-    "mapbox-gl": "^2.1.1",
     "framer-motion": "^3.3.0",
     "mapbox-gl": "^2.1.1",
     "react": "^17.0.1",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -15,6 +15,9 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!-- Font Imports -->
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import ArtMap from "./pages/ArtMap/ArtMap";
 import Compass from "./pages/Compass/Compass";
 import Camera from "./pages/Camera/Camera";
 import Artwork from "./pages/Artwork/Artwork";
+import StyleGuide from "./components/StyleGuide";
 import ArtSubmission from "./pages/ArtSubmission/ArtSubmission";
 function App() {
   return (
@@ -15,6 +16,7 @@ function App() {
         <Route path="/artwork/:id" component={Artwork} />
         <Route path="/camera" component={Camera} />
         <Route path="/art-submission" component={ArtSubmission} />
+        <Route path="/style-guide" component={StyleGuide} />
         <Route path="*" component={ArtMap} />
       </Switch>
     </Router>

--- a/frontend/src/components/MetricBadge/MetricBadge.jsx
+++ b/frontend/src/components/MetricBadge/MetricBadge.jsx
@@ -1,0 +1,10 @@
+import "./MetricBadge.scss";
+
+export default function MetricBadge({ value, unit, ...restProps }) {
+  return (
+    <div className="MetricBadge" {...restProps}>
+      <p className="value">{value}</p>
+      <p className="unit">{unit}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/MetricBadge/MetricBadge.scss
+++ b/frontend/src/components/MetricBadge/MetricBadge.scss
@@ -1,0 +1,16 @@
+.MetricBadge {
+  display: inline-block;
+  padding: 10px;
+  border-radius: 10px;
+  margin: 5px;
+  .value {
+    font-weight: 700;
+    font-size: 28px;
+    margin: 0;
+  }
+
+  .unit {
+    margin: 0;
+    font-size: 14px;
+  }
+}

--- a/frontend/src/components/StyleGuide.jsx
+++ b/frontend/src/components/StyleGuide.jsx
@@ -1,0 +1,38 @@
+import MetricBadge from "./MetricBadge/MetricBadge";
+
+export default function StyleGuide() {
+  return (
+    <section style={{ padding: "50px" }}>
+      <h1>Titles</h1>
+      <hr />
+
+      <h1>h1</h1>
+      <h2>h2</h2>
+      <h3>h3</h3>
+      <h2>Text</h2>
+      <hr />
+
+      <p>paragraph</p>
+      <h2>Buttons</h2>
+      <hr />
+
+      <button>button primary</button>
+      <hr />
+      <h2>Inputs</h2>
+      <hr />
+
+      <input type="text" placeholder="text input" />
+      <hr />
+      <h2>Components</h2>
+      <p>MetricBadge:</p>
+      <MetricBadge value={70} unit="Followers" />
+      <MetricBadge value={70} unit="Followers" />
+      <p>Some component ideas</p>
+      <ul>
+        {["Side Scroller", "Badge", "Nav", "TabBar", "TextField"].map((val) => (
+          <li>{val}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -20,30 +20,53 @@ body,
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+  font-family: "Inter", -apple-system, "Open Sans", "Roboto", "Oxygen", "Ubuntu",
+    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
 }
 
 nav {
   padding: 30px;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5 {
+  font-weight: 700;
+  margin: 20px 0;
+}
+
+h1 {
+  font-size: 42px;
+}
+
+h2 {
+  font-size: 32px;
+}
+
+h3 {
+  font-size: 20px;
+}
+
+p {
+  font-size: 16px;
+  font-weight: 500;
+}
+
 button {
   background: var(--c-primary);
   padding: 15px 30px;
+  margin: 5px;
   font-weight: 600;
+  font-size: 18px;
+  color: white;
   border: none;
   border-radius: 10px;
-  transition: transform 0.1s;
   cursor: pointer;
+  transition: transform 0.1s;
 }
 
 button.wrapper {
@@ -53,5 +76,22 @@ button.wrapper {
 }
 
 button:active {
-  transform: scale(0.95);
+  transform: scale(0.97);
+}
+
+input[type="text"],
+input[type="password"],
+input[type="number"] {
+  font-family: inherit;
+  font-size: 16px;
+  padding: 15px;
+  border-radius: 8px;
+  font-weight: 400;
+  border: 1px solid #c7c7c7;
+  background-color: #ebebeb;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
+    monospace;
 }


### PR DESCRIPTION
I added some default styles to the React project so that using bare HTML tags without styled classes will get you something close to what is in the design spec. Added styles for:
- Headers h1-5
- Input fields
- paragraphs
- buttons (`wrapper` class can be used to eliminate the color styling for wrapping icons)
- Metric Badge (component)

I also added a style guide component temporarily for development. You can view all of the styles in one place at [`http://localhost:3000/style-guide`](http://localhost:3000/style-guide)