### PR TITLE
Connect artwork page to backend, retrieve title, description, and tags

### DIFF
--- a/frontend/src/components/ConnectionErrorMessage/ConnectionErrorMessage.jsx
+++ b/frontend/src/components/ConnectionErrorMessage/ConnectionErrorMessage.jsx
@@ -1,0 +1,15 @@
+import "./ConnectionErrorMessage.scss";
+import { useHistory } from "react-router-dom";
+import { AlertCircle } from "react-feather";
+
+export default function ConnectionErrorMessage({ children }) {
+  const { goBack } = useHistory();
+
+  return (
+    <div className="error-message">
+      <AlertCircle size={35} />
+      <p>{children}</p>
+      <button onClick={goBack}>Go Back</button>
+    </div>
+  );
+}

--- a/frontend/src/components/ConnectionErrorMessage/ConnectionErrorMessage.jsx
+++ b/frontend/src/components/ConnectionErrorMessage/ConnectionErrorMessage.jsx
@@ -6,7 +6,7 @@ export default function ConnectionErrorMessage({ children }) {
   const { goBack } = useHistory();
 
   return (
-    <div className="error-message">
+    <div className="ConnectionErrorMessage">
       <AlertCircle size={35} />
       <p>{children}</p>
       <button onClick={goBack}>Go Back</button>

--- a/frontend/src/components/ConnectionErrorMessage/ConnectionErrorMessage.scss
+++ b/frontend/src/components/ConnectionErrorMessage/ConnectionErrorMessage.scss
@@ -1,0 +1,13 @@
+.ConnectionErrorMessage {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: gray;
+  text-align: center;
+
+  svg {
+    display: block;
+    margin: auto;
+  }
+}

--- a/frontend/src/pages/Artwork/Artwork.jsx
+++ b/frontend/src/pages/Artwork/Artwork.jsx
@@ -11,12 +11,10 @@ import {
 import exampleArt from "../../assets/example-art.jpg";
 import MetricBadge from "../../components/MetricBadge/MetricBadge";
 import Tag from "../../components/Tag/Tag";
+import ConnectionErrorMessage from "../../components/ConnectionErrorMessage/ConnectionErrorMessage";
 import { useParams, useHistory } from "react-router-dom";
 import { gql, useQuery } from '@apollo/client';
 
-const metrics = [{ value: 17, unit: "People Visited" },
-            { value: 12, unit: "Related Pieces"},
-            { value: 53, unit: "Comments"}];
 const rating = 3.2;
 
 export default function Artwork() {
@@ -30,6 +28,9 @@ export default function Artwork() {
             title
             description
             tags
+            metrics {
+              totalVisits
+            }
           }
         }
       }
@@ -39,17 +40,13 @@ export default function Artwork() {
   const { loading, error, data } = useQuery(query);
 
   if (loading) return (<h1>Loading...</h1>);
-  if (error) return (
-        <div className="error-message">
-          <AlertCircle size={35} />
-          <p>Error: {error.message}</p>
-          <button onClick={goBack}>Go Back</button>
-        </div>
-        );
+  if (error) return (<ConnectionErrorMessage>Error: {error.message}</ConnectionErrorMessage>);
 
   const artwork = data.artwork.edges[0]?.node;
 
-  if (artwork == undefined) return (<h1>Error: Artwork does not exist</h1>);
+  if (artwork == undefined) return (<ConnectionErrorMessage>Error: Artwork does not exist</ConnectionErrorMessage>);
+
+  const metrics = [{ value: artwork.metrics.totalVisits, unit: "Total Visits" },];
 
   return (
     <article className="Artwork">

--- a/frontend/src/pages/Artwork/Artwork.jsx
+++ b/frontend/src/pages/Artwork/Artwork.jsx
@@ -15,8 +15,6 @@ import ConnectionErrorMessage from "../../components/ConnectionErrorMessage/Conn
 import { useParams, useHistory } from "react-router-dom";
 import { gql, useQuery } from '@apollo/client';
 
-const rating = 3.2;
-
 export default function Artwork() {
   const { goBack } = useHistory();
   const { id } = useParams();
@@ -31,6 +29,7 @@ export default function Artwork() {
             metrics {
               totalVisits
             }
+            rating
           }
         }
       }
@@ -46,7 +45,8 @@ export default function Artwork() {
 
   if (artwork == undefined) return (<ConnectionErrorMessage>Error: Artwork does not exist</ConnectionErrorMessage>);
 
-  const metrics = [{ value: artwork.metrics.totalVisits, unit: "Total Visits" },];
+  const metrics = [{ value: artwork.metrics.totalVisits, unit: "Total Visits" },
+                   { value: artwork.rating, unit: "Stars" }];
 
   return (
     <article className="Artwork">

--- a/frontend/src/pages/Artwork/Artwork.jsx
+++ b/frontend/src/pages/Artwork/Artwork.jsx
@@ -11,7 +11,7 @@ import {
 import exampleArt from "../../assets/example-art.jpg";
 import MetricBadge from "../../components/MetricBadge/MetricBadge";
 import Tag from "../../components/Tag/Tag";
-import { useParams } from "react-router-dom";
+import { useParams, useHistory } from "react-router-dom";
 import { gql, useQuery } from '@apollo/client';
 
 const metrics = [{ value: 17, unit: "People Visited" },
@@ -20,6 +20,7 @@ const metrics = [{ value: 17, unit: "People Visited" },
 const rating = 3.2;
 
 export default function Artwork() {
+  const { goBack } = useHistory();
   const { id } = useParams();
   const query = gql`
     query {
@@ -38,7 +39,13 @@ export default function Artwork() {
   const { loading, error, data } = useQuery(query);
 
   if (loading) return (<h1>Loading...</h1>);
-  if (error) return (<h1>Error: {error.message}</h1>);
+  if (error) return (
+        <div className="error-message">
+          <AlertCircle size={35} />
+          <p>Error: {error.message}</p>
+          <button onClick={goBack}>Go Back</button>
+        </div>
+        );
 
   const artwork = data.artwork.edges[0]?.node;
 

--- a/frontend/src/pages/Artwork/Artwork.jsx
+++ b/frontend/src/pages/Artwork/Artwork.jsx
@@ -11,19 +11,39 @@ import {
 import exampleArt from "../../assets/example-art.jpg";
 import MetricBadge from "../../components/MetricBadge/MetricBadge";
 import Tag from "../../components/Tag/Tag";
+import { useParams } from "react-router-dom";
+import { gql, useQuery } from '@apollo/client';
 
-const artwork = {
-  title: "Some Artwork",
-  description:
-    "Lorem ipsum dolor sit amet consectetur, adipisicing elit. Laboriosam est atque, similique dignissimos itaque ipsum, nemo, dolore modi tempore esse voluptatem temporibus? Recusandae molestias dolor non beatae nobis enim debitis!",
-  tags: ["very", "noice", "tag3"],
-  metrics: [{ value: 17, unit: "People Visited" },
+const metrics = [{ value: 17, unit: "People Visited" },
             { value: 12, unit: "Related Pieces"},
-            { value: 53, unit: "Comments"}],
-  rating: 3.2,
-};
+            { value: 53, unit: "Comments"}];
+const rating = 3.2;
 
 export default function Artwork() {
+  const { id } = useParams();
+  const query = gql`
+    query {
+      artwork (id:"${id}") {
+        edges {
+          node {
+            title
+            description
+            tags
+          }
+        }
+      }
+    }
+  `;
+
+  const { loading, error, data } = useQuery(query);
+
+  if (loading) return (<h1>Loading...</h1>);
+  if (error) return (<h1>Error: {error.message}</h1>);
+
+  const artwork = data.artwork.edges[0]?.node;
+
+  if (artwork == undefined) return (<h1>Error: Artwork does not exist</h1>);
+
   return (
     <article className="Artwork">
       <header>
@@ -31,7 +51,7 @@ export default function Artwork() {
         <button className="wrapper back-button">
           <ArrowLeft />
         </button>
-        <h1>Artwork</h1>
+        <h1>{artwork.title}</h1>
         <div className="options">
           <button className="wrapper">
             <Upload />
@@ -44,8 +64,9 @@ export default function Artwork() {
 
       <div className="content">
         <p className="description">{artwork.description}</p>
+        
         <ul className="tags">
-          {artwork.tags.map((tag) => (
+          {artwork.tags?.map((tag) => (
             <li>
               <Tag>{tag}</Tag>
             </li>
@@ -54,7 +75,7 @@ export default function Artwork() {
 
         <h2>Stats</h2>
         <div className="metric-badges">
-          {artwork.metrics.map((metric) => (
+          {metrics.map((metric) => (
             <MetricBadge {...metric} />
           ))}
         </div>

--- a/frontend/src/pages/Profile/Profile.jsx
+++ b/frontend/src/pages/Profile/Profile.jsx
@@ -3,6 +3,7 @@ import { useQuery, gql } from "@apollo/client";
 import { MoreHorizontal, AlertCircle } from "react-feather";
 import { useHistory } from "react-router-dom";
 import MetricBadge from "../../components/MetricBadge/MetricBadge";
+import ConnectionErrorMessage from "../../components/ConnectionErrorMessage/ConnectionErrorMessage";
 import exampleProfile from "../../assets/example-profile.jpg";
 
 const GET_USER_QUERY = gql`
@@ -22,8 +23,9 @@ const GET_USER_QUERY = gql`
     }
   }
 `;
+
 export default function Profile() {
-  const { data, loading, error } = useQuery(GET_USER_QUERY);
+  const { loading, error, data } = useQuery(GET_USER_QUERY);
 
   const { goBack } = useHistory();
   const user = data?.users.edges[1].node;
@@ -31,11 +33,7 @@ export default function Profile() {
   return (
     <article className="Profile">
       {error ? (
-        <div className="error-message">
-          <AlertCircle size={35} />
-          <p>Couldn't find user info</p>
-          <button onClick={goBack}>Go Back</button>
-        </div>
+        <ConnectionErrorMessage>Error: Couldn't find user info</ConnectionErrorMessage>
       ) : (
         <>
           <header>


### PR DESCRIPTION
## Summary
The artwork page can now connect to the backend and fill out the discovered artwork page with a given artwork's title, description, and tags.

Fixes #33.

## How To Test
1. Go into your virtual environment: `pipenv install && pipenv shell`
2. Start the backend server (local): `python app.py -l`
3. Go to `http://127.0.0.1:5000/graphql` and paste in this query:
```
query {
  artwork {
    edges {
      node {
        id
      }
    }
  }
}
```
4. Choose an id and copy it
5. Start the frontend: `npm install && npm start`
6. Go to `http://localhost:3000/artwork/{your_copied_id_here}`

You should see the art page for the artwork whose id you selected. None of the artworks currently have tags so there will be none. Also, artworks don't have a metrics property so the metrics are a constant in the frontend, and are the same for every artwork.

If you pass in a valid id for an artwork that doesn't exist (like QXJ0d29ya1R5cGU6NjA0OTEwZmQyNzc0OGZkOThkOWI3ZjRh) you should get an error message saying that the artwork doesn't exist.