### PR TITLE
Added custom primary keys to Documents and Added group mutations

### DIFF
--- a/backend/api_types.py
+++ b/backend/api_types.py
@@ -1,9 +1,17 @@
 from graphene.relay import Node
 from models import Settings, User, UserMetrics, Achievement, Artwork, ArtworkMetrics
 from models import Comment, Portfolio, Group
-
 from graphene_mongo import MongoengineObjectType
+import graphene
 
+
+class CustomNode(graphene.Node):    # Node that has the same id as Mongo db
+    class Meta:
+        name = 'IdNode'
+
+    @staticmethod
+    def to_global_id(type, id):
+        return id
 
 class SettingsType(MongoengineObjectType):
     class Meta:
@@ -15,41 +23,39 @@ class UserType(MongoengineObjectType):
         filter_fields = {
             'name': ['exact', 'icontains', 'istartswith'],
         }
-        interfaces = (Node,)
+        interfaces = (CustomNode,)
 
 class UserMetricsType(MongoengineObjectType):
     class Meta:
         model = UserMetrics
-        interfaces = (Node,)
 
 class AchievementType(MongoengineObjectType):
     class Meta:
         model = Achievement
-        interfaces = (Node,)
+        interfaces = (CustomNode,)
 
 class ArtworkType(MongoengineObjectType):
     class Meta:
         model = Artwork
-        interfaces = (Node,)
+        interfaces = (CustomNode,)
     def resolve_tags(self, info):
         print("tags")
 
 class ArtworkMetricsType(MongoengineObjectType):
     class Meta:
         model = ArtworkMetrics
-        interfaces = (Node,)
 
 class CommentType(MongoengineObjectType):
     class Meta:
         model = Comment
-        interfaces = (Node,)
+        interfaces = (CustomNode,)
 
 class PortfolioType(MongoengineObjectType):
     class Meta:
         model = Portfolio
-        interfaces = (Node,)
+        interfaces = (CustomNode,)      # Uses node because groups can have multiple portfolios
 
 class GroupType(MongoengineObjectType):
     class Meta:
         model = Group
-        interfaces = (Node,)
+        interfaces = (CustomNode,)

--- a/backend/api_types.py
+++ b/backend/api_types.py
@@ -7,23 +7,36 @@ import graphene
 
 class CustomNode(graphene.Node):    # Node that has the same id as Mongo db
     class Meta:
-        name = 'IdNode'
+        name = 'Node'
 
     @staticmethod
     def to_global_id(type, id):
+        print("id: " + id)
         return id
+    
+    # @staticmethod
+    # def from_global_id(global_id):
+    #     print("global_id: " + global_id)
+    #     return global_id
+
+    @staticmethod
+    def get_node_from_global_id(info, global_id, only_type=None):
+        print("\nget_node_from_global_id is being called\n")
+        type_, id = global_id.split(':')
+        print(type_ + ", " + id)
 
 class SettingsType(MongoengineObjectType):
     class Meta:
         model = Settings
 
 class UserType(MongoengineObjectType):
+    interfaces = (CustomNode,)
     class Meta:
         model = User
         filter_fields = {
             'name': ['exact', 'icontains', 'istartswith'],
         }
-        interfaces = (CustomNode,)
+        
 
 class UserMetricsType(MongoengineObjectType):
     class Meta:

--- a/backend/api_types.py
+++ b/backend/api_types.py
@@ -5,37 +5,17 @@ from graphene_mongo import MongoengineObjectType
 import graphene
 
 
-class CustomNode(graphene.Node):    # Node that has the same id as Mongo db
-    class Meta:
-        name = 'Node'
-
-    @staticmethod
-    def to_global_id(type, id):
-        print("id: " + id)
-        return id
-    
-    # @staticmethod
-    # def from_global_id(global_id):
-    #     print("global_id: " + global_id)
-    #     return global_id
-
-    @staticmethod
-    def get_node_from_global_id(info, global_id, only_type=None):
-        print("\nget_node_from_global_id is being called\n")
-        type_, id = global_id.split(':')
-        print(type_ + ", " + id)
-
 class SettingsType(MongoengineObjectType):
     class Meta:
         model = Settings
 
 class UserType(MongoengineObjectType):
-    interfaces = (CustomNode,)
     class Meta:
         model = User
         filter_fields = {
             'name': ['exact', 'icontains', 'istartswith'],
         }
+        interfaces = (Node,)
         
 
 class UserMetricsType(MongoengineObjectType):
@@ -45,12 +25,12 @@ class UserMetricsType(MongoengineObjectType):
 class AchievementType(MongoengineObjectType):
     class Meta:
         model = Achievement
-        interfaces = (CustomNode,)
+        interfaces = (Node,)
 
 class ArtworkType(MongoengineObjectType):
     class Meta:
         model = Artwork
-        interfaces = (CustomNode,)
+        interfaces = (Node,)
     def resolve_tags(self, info):
         print("tags")
 
@@ -61,14 +41,14 @@ class ArtworkMetricsType(MongoengineObjectType):
 class CommentType(MongoengineObjectType):
     class Meta:
         model = Comment
-        interfaces = (CustomNode,)
+        interfaces = (Node,)
 
 class PortfolioType(MongoengineObjectType):
     class Meta:
         model = Portfolio
-        interfaces = (CustomNode,)      # Uses node because groups can have multiple portfolios
+        interfaces = (Node,)      # Uses node because groups can have multiple portfolios
 
 class GroupType(MongoengineObjectType):
     class Meta:
         model = Group
-        interfaces = (CustomNode,)
+        interfaces = (Node,)

--- a/backend/api_types.py
+++ b/backend/api_types.py
@@ -31,8 +31,6 @@ class ArtworkType(MongoengineObjectType):
     class Meta:
         model = Artwork
         interfaces = (Node,)
-    def resolve_tags(self, info):
-        print("tags")
 
 class ArtworkMetricsType(MongoengineObjectType):
     class Meta:

--- a/backend/database.py
+++ b/backend/database.py
@@ -32,10 +32,10 @@ def init_db():
     ]
 
     users = [
-        User(name="Grant", personal_portfolio=portfolios[0], bio="Love me some AI and maybe web dev.", metrics=UserMetrics(), achievements=[achievements[1], achievements[0]]),
-        User(name="Braden", personal_portfolio=portfolios[1], bio="Spending some time on CSC 400.", metrics=UserMetrics(), achievements=[achievements[1]]),
-        User(name="Kyle", personal_portfolio=portfolios[2], bio="Fitness, meditation and good books.", metrics=UserMetrics(), achievements=[achievements[1], achievements[0]]),
-        User(name="John", personal_portfolio=portfolios[3], bio="Looking around for some art. Wasn't satisfied with my dope Windows Vista wallpaper.", metrics=UserMetrics(), achievements=[achievements[1]])
+        User(name="Grant", personal_portfolio=portfolios[0], bio="Love me some AI and maybe web dev.", email="grant@grant.com", metrics=UserMetrics(), achievements=[achievements[1], achievements[0]]),
+        User(name="Braden", personal_portfolio=portfolios[1], bio="Spending some time on CSC 400.", email="braden@braden.com", metrics=UserMetrics(), achievements=[achievements[1]]),
+        User(name="Kyle", personal_portfolio=portfolios[2], bio="Fitness, meditation and good books.", email="kyle@kyle.com", metrics=UserMetrics(), achievements=[achievements[1], achievements[0]]),
+        User(name="John", personal_portfolio=portfolios[3], bio="Looking around for some art. Wasn't satisfied with my dope Windows Vista wallpaper.", email="john@john.com", metrics=UserMetrics(), achievements=[achievements[1]])
     ]
 
     for user in users:

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from mongoengine import Document, EmbeddedDocument, CASCADE
 from mongoengine.fields import DateTimeField, ReferenceField, StringField, IntField, ListField, PointField, FloatField, BooleanField, EmbeddedDocumentField
+from mongoengine.fields import ObjectIdField
+from bson.objectid import ObjectId
 
 
 # Note: In reference fields, dbref = True will use DBRef whereas if it is false, the ObjectId will be used
@@ -17,7 +19,7 @@ class UserMetrics(EmbeddedDocument):
     works_visited = IntField(default=0)
     works_found = IntField(default=0)
     cities_visited = IntField(default=0)
-    posts_written = IntField(default=0) # not entirely sure what this represents, might wanna change it to works_created
+    locations_created = IntField(default=0) # not entirely sure what this represents, might wanna change it to works_created
 
 class User(Document):
     meta = {"collection": "user"}
@@ -66,6 +68,6 @@ class Group(Document):
     name = StringField(required=True)
     bio = StringField()
     members = ListField(ReferenceField("User"), default=list)
-    portfolio = EmbeddedDocumentField("Portfolio")
+    group_portfolio = EmbeddedDocumentField("Portfolio")
     chat = ListField(EmbeddedDocumentField("Comment"), default=list)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -18,13 +18,14 @@ class Portfolio(EmbeddedDocument):
 class UserMetrics(EmbeddedDocument):
     works_visited = IntField(default=0)
     works_found = IntField(default=0)
+    works_created = IntField(default=0)
     cities_visited = IntField(default=0)
-    locations_created = IntField(default=0) # not entirely sure what this represents, might wanna change it to works_created
 
 class User(Document):
     meta = {"collection": "user"}
     name = StringField(required=True)
     bio = StringField()
+    email = StringField(primary_key=True, required=True)
     profile_pic = StringField()
     date_joined = DateTimeField(default=datetime.now)
     metrics = EmbeddedDocumentField("UserMetrics", dbref=True)
@@ -35,7 +36,7 @@ class User(Document):
 
 class Achievement(Document):
     meta = {"collection" : "achievement"}
-    title = StringField(required=True)
+    title = StringField(primary_key=True, required=True)
     description = StringField(required=True)
     points = IntField(required=True)
     # might wanna have metrics that have to be met to obtain
@@ -53,11 +54,11 @@ class Artwork(Document):
         "collection": "artwork",
         #"indexes": [("location", "2dsphere")]
     }
-    title = StringField(required=True)
+    title = StringField(required=True, primary_key=True)    # Making this primary key for now despite it not being unique
     artist = StringField(required=False)
     description = StringField(required=True)
     found_by = ReferenceField("User")
-    location = PointField()
+    location = PointField(required=True)
     metrics = EmbeddedDocumentField("ArtworkMetrics", default=ArtworkMetrics)
     rating = FloatField(min_value=0, max_value=100)
     comments = ListField(EmbeddedDocumentField("Comment"), default=list)
@@ -65,7 +66,7 @@ class Artwork(Document):
 
 class Group(Document):
     meta = {"collection": "group"}
-    name = StringField(required=True)
+    name = StringField(primary_key=True, required=True)     # Making this primary key for now despite it not being unique
     bio = StringField()
     members = ListField(ReferenceField("User"), default=list)
     group_portfolio = EmbeddedDocumentField("Portfolio")

--- a/backend/mutations.py
+++ b/backend/mutations.py
@@ -108,11 +108,13 @@ class UserMetricsInput(graphene.InputObjectType):
     cities_visited = graphene.Int()
     posts_written = graphene.Int()
 
+
 class UserInput(graphene.InputObjectType):
     # since this class is generalized for all updating and creating, won't make any attributes required
     id = graphene.String()
     name = graphene.String()
     bio = graphene.String()
+    email = graphene.String()
     profile_pic = graphene.String()   # NOTE: will assume base64 encoded string
     metrics = graphene.InputField(UserMetricsInput)
     achievement = graphene.String()     # achievement id to add to user's achievements
@@ -139,6 +141,7 @@ class CreateUserMutation(graphene.Mutation):
             # Need to eventually add username (if that's not the 'name') and password
             name = user_data.name,
             bio = user_data.bio,    # not required by model, will assume frontend filters input
+            email = user_data.email,
             profile_pic = user_data.profile_pic,
             metrics = metrics,
             achievements = [], # will likely want to add a hard coded initial achievement
@@ -150,7 +153,8 @@ class CreateUserMutation(graphene.Mutation):
 
         return CreateUserMutation(user=user, id=user.id)
 
-
+# Querying by id as an "id" argument should be by encoded string
+# id within user_input will be the primary key (email right now)
 class UpdateUserMutation(graphene.Mutation):
     user = graphene.Field(UserType)
 
@@ -163,6 +167,8 @@ class UpdateUserMutation(graphene.Mutation):
             user.name = user_data.name
         if user_data.bio:
             user.bio = user_data.bio
+        if user_data.email: # don't think I want this while primary key is email
+            user.email = user_data.email
         if user_data.metrics:
             user.metrics = UserMetrics(
                 works_visited = user_data.metrics.works_visited,
@@ -336,7 +342,7 @@ mutation {
         worksVisited,
         worksFound,
         citiesVisited,
-        postsWritten
+        worksCreated
       }
       achievements {
         edges {
@@ -404,7 +410,7 @@ mutation {
         worksVisited,
         worksFound,
         citiesVisited,
-        postsWritten
+        worksCreated
       }
       achievements {
         edges {

--- a/backend/schema.py
+++ b/backend/schema.py
@@ -2,15 +2,13 @@ import graphene
 from graphene.relay import Node
 from mutations import UpdateUserMutation, CreateUserMutation, DeleteUserMutation, CreateArtworkMutation, UpdateArtworkMutation
 from mutations import DeleteArtworkMutation
-from api_types import UserType, PortfolioType, ArtworkType, AchievementType, GroupType, CustomNode
+from api_types import UserType, PortfolioType, ArtworkType, AchievementType, GroupType
 from graphene_mongo import MongoengineConnectionField
 from models import Artwork
 
 
-
-
 class Query(graphene.ObjectType):
-    node = CustomNode.Field()       # Changed this from node to custom node (was Node.field())
+    #node = Node.Field()
     users = MongoengineConnectionField(UserType)
     groups = MongoengineConnectionField(GroupType)
     artwork = MongoengineConnectionField(ArtworkType)

--- a/backend/schema.py
+++ b/backend/schema.py
@@ -2,7 +2,7 @@ import graphene
 from graphene.relay import Node
 from mutations import UpdateUserMutation, CreateUserMutation, DeleteUserMutation, CreateArtworkMutation, UpdateArtworkMutation
 from mutations import DeleteArtworkMutation
-from api_types import UserType, PortfolioType, ArtworkType, AchievementType, GroupType
+from api_types import UserType, PortfolioType, ArtworkType, AchievementType, GroupType, CustomNode
 from graphene_mongo import MongoengineConnectionField
 from models import Artwork
 
@@ -10,7 +10,7 @@ from models import Artwork
 
 
 class Query(graphene.ObjectType):
-    node = Node.Field()
+    node = CustomNode.Field()       # Changed this from node to custom node (was Node.field())
     users = MongoengineConnectionField(UserType)
     groups = MongoengineConnectionField(GroupType)
     artwork = MongoengineConnectionField(ArtworkType)

--- a/backend/testing.py
+++ b/backend/testing.py
@@ -133,7 +133,7 @@ def test_removing_artwork(client, userNameId, artworkNameId):
             }}
         }} }}
         """.format(userNameId[1]))
-    
+
     added = client.execute("""
         mutation {{
             updateUser(userData: {{

--- a/backend/testing.py
+++ b/backend/testing.py
@@ -9,8 +9,8 @@ def testing_boot_up():
     # NOTE: Must use camel-case in graphql calls, can change this if wanted
     client = Client(schema)
     users_with_ids, artworks_with_ids = mock_db_setup(client)
-    # print(users_with_ids)
-    # print(artworks_with_ids)
+    print(users_with_ids)
+    print(artworks_with_ids)
     run_tests(client, users_with_ids, artworks_with_ids)
 
 
@@ -113,6 +113,29 @@ def assign_artworks(client, users_with_ids, artworks_with_ids):
 def test_removing_artwork(client, userNameId, artworkNameId):
     ''' Will add the artwork, and then delete it
         Assumptions: update mutation works to add artwork and artwork isn't already in user's portfolio '''
+    print("test1")
+    test1 = client.execute("""
+        {{
+            users(id: "{0}") {{
+                edges {{
+                    node {{
+                        name
+                    }}
+                }}
+            }}
+        }}
+    """.format(userNameId[1]))
+
+    print("test2")
+    test2 = client.execute("""
+    query {{
+        node(id: "604917bc04a5be639b6fb2bd") {{
+            id
+        }}
+    }}
+    """)
+    print(test2)
+    
     before = client.execute("""
         mutation {{
             updateUser(userData: {{
@@ -179,7 +202,3 @@ def test_removing_artwork(client, userNameId, artworkNameId):
         """.format(userNameId[1], artworkNameId[1]))
     if removed != before:
         print("Artwork Removal Failed")
-
-
-
-

--- a/backend/testing.py
+++ b/backend/testing.py
@@ -17,10 +17,11 @@ def testing_boot_up():
 def mock_db_setup(client):
     ''' Will create a mock database with all relational objects
         Currently, just users and artworks are created and related '''
-    users_with_ids = create_users(client) # creates users
+    users_with_ids = create_users(client)
     artworks_with_ids = create_artworks(client, users_with_ids) # creates artworks, each with a user that "created" it
     assign_artworks(client, users_with_ids, artworks_with_ids)  # makes sure each user's portfolio contains the artwork they created
     return users_with_ids, artworks_with_ids
+    #return users_with_ids, []
 
 
 def run_tests(client, users_with_ids, artworks_with_ids):
@@ -46,13 +47,13 @@ def create_users(client):
                     email: "{2}"
   	            }}
 	        ) {{
-                id
                 user {{
-                  name
+                    id
+                    name
                 }}
             }}
         }}""".format(user_input[0], user_input[1], user_input[2]))
-        users_with_ids.append((user_input[0], executed["data"]["createUser"]["id"]))
+        users_with_ids.append((executed["data"]["createUser"]["user"]["name"], executed["data"]["createUser"]["user"]["id"]))
         # append (user's name, user id)
     return(users_with_ids)
     
@@ -63,7 +64,7 @@ def create_artworks(client, users_with_ids):
         ("Hidden Subway Mural", "Far side of the subway station has a double walled mural.", users_with_ids[0][1], "[-120.677494, 35.292708]", "55.0", "[\"sick\", \"rad\"]"),
         ("Blue Bridge", "Neon blue tentacles of paint wind up the struts of the bridge", users_with_ids[1][1], "[-121.677494, 32.292708]", "75.0", "[\"sick\", \"blue\"]"),
         ("Artistic Underpass", "Bridge ceiling covered in art", users_with_ids[2][1], "[-120.777494, 34.292708]", "99.0", "[\"overwhelming\", \"scary\"]"),
-        ("Fire Wall", "Tongues of flame comemorate the historic fire of this district", users_with_ids[3][1], "[-122.677494, 35.282708]", "32.0", "[\"unsafe\", \"exciting\"]")
+        ("Fire Wall", "Tongues of flame comemorate the historic fire of this district", users_with_ids[3][1], "[-122.677494, 35.282708]", "32.0", "[]")
     ]   # Might wanna change location data for more testable locations (like within radius of me)
 
     artworks_with_ids = []
@@ -78,14 +79,14 @@ def create_artworks(client, users_with_ids):
                 rating: {4},
                 tags: {5}
             }}) {{
-                id
                 artwork {{
-                  title
+                    id
+                    title
+                    tags
                 }}
-                tags
             }}
         }}""".format(artwork[0], artwork[1], artwork[2], artwork[3], artwork[4], artwork[5]))
-        artworks_with_ids.append((artwork[0], executed["data"]["createArtwork"]["id"]))
+        artworks_with_ids.append((executed["data"]["createArtwork"]["artwork"]["title"], executed["data"]["createArtwork"]["artwork"]["id"]))
     return artworks_with_ids
 
 def assign_artworks(client, users_with_ids, artworks_with_ids):


### PR DESCRIPTION
Added custom primary keys for the purpose of demonstration and testing. There are a couple problems with this:

- Both Artworks and Groups have a primary key related to their names/titles. 
       Currently, the creation of an artwork or group with the same name of one in the database, will cause the new object to override the id of the old one and it nulls out the old object (not deletes, it just shows up as an empty node). This makes it so a change of group or artwork name would complicate things (similar to below)
       NOTE: Artworks have a unique location attribute, but it is a special point object and I was getting errors when trying to treat it as the primary key, so I switched to title.

- Can't change user email
        Currently, If you try to change the user email then it creates a shell object with just the information provided to the update mutation. It doesn't actually update the user. Even if it did update the email, then the email would be out of sync with the id and that wouldn't be good. If it did update the id for the user then that could mess up dependencies elsewhere

Update: I added the decoding to each mutation, so now the frontend only has one type of id for each object to worry about. To my current understanding, the primary keys could be removed, and the backend would still work as expected.