### PR TITLE
Added map animations

### DIFF
--- a/frontend/src/pages/ArtMap/ArtMap.scss
+++ b/frontend/src/pages/ArtMap/ArtMap.scss
@@ -8,11 +8,15 @@
     color: var(--c-primary);
   }
 
+  .absolute {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+  }
+
   .card {
     z-index: 20;
-    nav {
-      padding: 0;
-    }
     position: absolute;
     bottom: 10px;
     left: 10px;
@@ -31,6 +35,16 @@
       bottom: 0px;
       left: 0px;
       width: 100%;
+    }
+
+    nav {
+      padding: 0;
+    }
+
+    .content {
+      position: relative;
+      width: 100%;
+      height: 100%;
     }
   }
 


### PR DESCRIPTION
Finalized the map screen a bit with some animations:
- Clicking on clusters and art markers will zoom the map to that location
- Selecting an artwork on the cluster popup card will have a slide in /out effect. Dismissing artwork after selecting it on cluster card will slide the cluster card back in from the left.