### PR TITLE
Claim Artwork on the Map

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -14,7 +14,7 @@ def init_db():
         achievement.save()
 
     art = [
-        Artwork(title="Street Art", description="A true masterpiece", pictures=[get_sample_encoded_art_image()], location=[-120.71691615739553, 35.25274443264594], rating=25),
+        Artwork(title="Street Art", description="A true masterpiece", pictures=[get_sample_encoded_art_image()], location=[-120.664, 35.258], rating=25),
         Artwork(title="Hidden Subway Mural", description="Far side of the subway station has a double walled mural.", pictures=[get_sample_encoded_art_image()], location=[-120.67759172519696, 35.23446092387092], rating=89, metrics=ArtworkMetrics(total_visits=2000)),
         Artwork(title="Blue Bridge", description="Neon blue tentacles of paint wind up the struts of the bridge", pictures=[get_sample_encoded_art_image()], tags=["amazing"], location=[-120.70919388389524, 35.292870133451174], rating=90, metrics=ArtworkMetrics(total_visits=32)),
         Artwork(title="Artistic Underpass", description="Bridge ceiling covered in art", pictures=[get_sample_encoded_art_image()], tags=["surreal", "amazing"], location=[-120.69407509793804, 35.283794177611576], rating=97, metrics=ArtworkMetrics(total_visits=5127)),

--- a/frontend/src/pages/ArtMap/ArtMap.scss
+++ b/frontend/src/pages/ArtMap/ArtMap.scss
@@ -91,6 +91,13 @@
       transform: rotate(315deg) translateX(-50%);
     }
   }
+
+  .claim-button {
+    position: absolute;
+    bottom: 30px;
+    left: 50%;
+    transform:translate(-50%, 0);
+  }
 }
 
 .ArtChoices {

--- a/frontend/src/pages/ArtMap/components/ArtInfo.jsx
+++ b/frontend/src/pages/ArtMap/components/ArtInfo.jsx
@@ -5,30 +5,31 @@ export default function ArtInfo({
   description,
   rating,
   title,
-  tags,
+  tags = [],
   metrics,
   distance,
   onConfirm,
+  id,
 }) {
   return (
     <div className="ArtInfo">
       <h2>{title}</h2>
       <p>{description}</p>
       <div className="metrics">
-        {rating && <MetricBadge value={rating} unit="star rating" />}
-        {metrics?.totalVisits && (
+        {rating ? <MetricBadge value={rating} unit="star rating" /> : null}
+        {metrics?.totalVisits ? (
           <MetricBadge value={metrics.totalVisits} unit="visitors" />
-        )}
-        {distance && <MetricBadge value={distance} unit="miles away" />}
+        ) : null}
+        {distance ? <MetricBadge value={distance} unit="miles away" /> : null}
       </div>
 
-      {tags && (
+      {tags.length ? (
         <ul className="wrapper">
           {tags.map((tag) => (
             <Tag key={tag}>{tag}</Tag>
           ))}
         </ul>
-      )}
+      ) : null}
       <button onClick={onConfirm}>Let's Go</button>
     </div>
   );

--- a/frontend/src/pages/ArtMap/queries.js
+++ b/frontend/src/pages/ArtMap/queries.js
@@ -22,6 +22,15 @@ const queries = {
       }
     }
   `,
+  addArtworkToPortfolio: gql`
+    mutation addArtwork($userId: String!, $artId: String!) {
+      updateUser(userData: { id: $userId, artToAdd: $artId }) {
+        user {
+          id
+        }
+      }
+    }
+  `,
 };
 
 export default queries;

--- a/frontend/src/pages/Artwork/Artwork.jsx
+++ b/frontend/src/pages/Artwork/Artwork.jsx
@@ -13,7 +13,7 @@ import MetricBadge from "../../components/MetricBadge/MetricBadge";
 import Tag from "../../components/Tag/Tag";
 import ConnectionErrorMessage from "../../components/ConnectionErrorMessage/ConnectionErrorMessage";
 import { useParams, useHistory } from "react-router-dom";
-import { gql, useQuery } from '@apollo/client';
+import { gql, useQuery } from "@apollo/client";
 
 export default function Artwork() {
   const { goBack } = useHistory();
@@ -38,21 +38,31 @@ export default function Artwork() {
 
   const { loading, error, data } = useQuery(query);
 
-  if (loading) return (<h1>Loading...</h1>);
-  if (error) return (<ConnectionErrorMessage>Error: {error.message}</ConnectionErrorMessage>);
+  if (loading) return <h1>Loading...</h1>;
+  if (error)
+    return (
+      <ConnectionErrorMessage>Error: {error.message}</ConnectionErrorMessage>
+    );
 
   const artwork = data.artwork.edges[0]?.node;
 
-  if (artwork == undefined) return (<ConnectionErrorMessage>Error: Artwork does not exist</ConnectionErrorMessage>);
+  if (artwork == undefined)
+    return (
+      <ConnectionErrorMessage>
+        Error: Artwork does not exist
+      </ConnectionErrorMessage>
+    );
 
-  const metrics = [{ value: artwork.metrics.totalVisits, unit: "Total Visits" },
-                   { value: artwork.rating, unit: "Stars" }];
+  const metrics = [
+    { value: artwork.metrics.totalVisits, unit: "Total Visits" },
+    { value: artwork.rating, unit: "Stars" },
+  ];
 
   return (
     <article className="Artwork">
       <header>
         <img src={exampleArt} alt="Art" />
-        <button className="wrapper back-button">
+        <button className="wrapper back-button" onClick={goBack}>
           <ArrowLeft />
         </button>
         <h1>{artwork.title}</h1>
@@ -68,7 +78,7 @@ export default function Artwork() {
 
       <div className="content">
         <p className="description">{artwork.description}</p>
-        
+
         <ul className="tags">
           {artwork.tags?.map((tag) => (
             <li>


### PR DESCRIPTION
On the Art Map, you can now claim artwork when you are within a certain distance. Claiming artwork takes you to the artwork's homepage and adds it to your user's `personalPortfolio` on the server.

## Testing
1. Start up backend and frontend servers.
2. Go to the `ArtMap.jsx` file and change the variable `const claimableDistance = 0.15` to something like `const claimableDistance = 100`. This will ensure that you can claim all artworks, even if you aren't close to them.
3. Click on an artwork marker
4. Click "Lets Go" to start navigating.
5. When within distance (any distance for you), the "Add to Portfolio" button should pop up. Click on it.
6. Ensure that you see the Art page

### Ensure the mutation worked correctly.
If you want to verify the mutation, I'm currently adding the artwork to the user with id `VXNlclR5cGU6am9obkBqb2huLmNvbQ==`