### PR TITLE
Visited Artwork Indicators

### DIFF
--- a/frontend/src/components/TabBar/TabBar.scss
+++ b/frontend/src/components/TabBar/TabBar.scss
@@ -3,7 +3,7 @@
 .TabBar {
     padding: 20px;
     padding-bottom: 15px;
-    position: absolute;
+    position: fixed;
     bottom:0;
     left: 0;
     background: white;

--- a/frontend/src/hooks/useProfileInfo.js
+++ b/frontend/src/hooks/useProfileInfo.js
@@ -1,7 +1,7 @@
 import { useQuery, gql } from "@apollo/client";
 import { useEffect, useState } from "react";
 
-let uid = "";
+let uid = "VXNlclR5cGU6am9obkBqb2huLmNvbQ==";
 let listeners = [];
 const GET_USER_QUERY = gql`
   query fetchUser($id: ID!) {
@@ -27,7 +27,7 @@ const GET_USER_QUERY = gql`
  * @returns {{profile: {name : string, id: string, bio : string, profilePic:string, metrics : {worksFound: number, worksVisited: number}}, error: object, setUser: function}} A user profile and any errors that may have occurred in fetching
  */
 export default function useProfileInfo() {
-  const listener = useState(Date.now())[1];
+  const listener = useState(null)[1];
   const { data, error } = useQuery(GET_USER_QUERY, {
     variables: { id: uid },
   });
@@ -35,7 +35,7 @@ export default function useProfileInfo() {
 
   function setUser(id) {
     uid = id;
-    listeners.forEach((l) => l(Date.now()));
+    listeners.forEach((l) => l(id));
   }
 
   useEffect(() => {

--- a/frontend/src/pages/ArtMap/ArtMap.scss
+++ b/frontend/src/pages/ArtMap/ArtMap.scss
@@ -99,6 +99,10 @@
       height: $size;
       transform: rotate(315deg) translateX(-50%);
     }
+
+    &.visited {
+      --c-primary: var(--c-accent);
+    }
   }
 
   .claim-button {
@@ -121,6 +125,7 @@
     list-style: none;
     padding: 0;
     max-height: 50vh;
+    overflow-y: scroll;
   }
   .ArtChoice {
     display: flex;

--- a/frontend/src/pages/ArtMap/components/ArtChoices.jsx
+++ b/frontend/src/pages/ArtMap/components/ArtChoices.jsx
@@ -17,12 +17,15 @@ export default function ArtChoices({ artworks, onArtworkSelected }) {
   );
 }
 
-function ArtChoice({ onClick, rating, title }) {
+function ArtChoice({ onClick, rating, title, visited }) {
   return (
     <li onClick={onClick} className="ArtChoice">
       <h3 className="title">{title}</h3>
       <p className="rating">
-        {rating} <Star />
+        {rating}{" "}
+        <Star
+          style={{ color: visited ? "var(--c-accent)" : "var(--c-primary)" }}
+        />
       </p>
     </li>
   );

--- a/frontend/src/pages/ArtMap/components/ArtInfo.jsx
+++ b/frontend/src/pages/ArtMap/components/ArtInfo.jsx
@@ -1,5 +1,6 @@
 import MetricBadge from "../../../components/MetricBadge/MetricBadge";
 import Tag from "../../../components/Tag/Tag";
+import { useHistory } from "react-router-dom";
 
 export default function ArtInfo({
   description,
@@ -9,8 +10,10 @@ export default function ArtInfo({
   metrics,
   distance,
   onConfirm,
+  visited,
   id,
 }) {
+  const history = useHistory();
   return (
     <div className="ArtInfo">
       <h2>{title}</h2>
@@ -30,7 +33,13 @@ export default function ArtInfo({
           ))}
         </ul>
       ) : null}
-      <button onClick={onConfirm}>Let's Go</button>
+      {visited ? (
+        <button onClick={() => history.push("/artwork/" + id)}>
+          View In Portfolio
+        </button>
+      ) : (
+        <button onClick={onConfirm}>Let's Go</button>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/ArtMap/queries.js
+++ b/frontend/src/pages/ArtMap/queries.js
@@ -31,6 +31,25 @@ const queries = {
       }
     }
   `,
+  getSeenArtworkIds: gql`
+    query getSeenArt($id: ID!) {
+      users(id: $id) {
+        edges {
+          node {
+            personalPortfolio {
+              artworks {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
 };
 
 export default queries;

--- a/frontend/src/pages/ArtSubmission/ArtSubmission.jsx
+++ b/frontend/src/pages/ArtSubmission/ArtSubmission.jsx
@@ -2,8 +2,8 @@ import "./ArtSubmission.scss";
 
 import { useMutation, gql } from "@apollo/client";
 import Rating from "react-rating-stars-component";
-import { useState, useRef } from "react";
-import { ArrowLeft, Star } from "react-feather";
+import { useState } from "react";
+import { ArrowLeft } from "react-feather";
 import { useHistory } from "react-router-dom";
 import { useForm, Controller, useController } from "react-hook-form";
 import usePhotoLibrary from "../../hooks/usePhotoLibrary";
@@ -90,7 +90,7 @@ export default function ArtSubmission() {
             <ArrowLeft />
           </button>
         </nav>
-        <img src={images[0]} alt="Art Image" />
+        <img src={images[0]} alt="Art" />
         <h1>New Artwork</h1>
       </header>
       <form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/src/pages/Artwork/Artwork.scss
+++ b/frontend/src/pages/Artwork/Artwork.scss
@@ -17,12 +17,17 @@
       left: $abs-pad;
       color: white;
       margin: 0;
+      filter: var(--text-shadow)
     }
 
     .back-button {
       position: absolute;
       top: $abs-pad;
       left: $abs-pad;
+
+      svg {
+        filter: var(--text-shadow)
+      }
     }
 
     .options {

--- a/frontend/src/pages/Portfolio/Portfolio.jsx
+++ b/frontend/src/pages/Portfolio/Portfolio.jsx
@@ -30,7 +30,7 @@ const GET_PORTFOLIO = gql`
 
 export default function Portfolio() {
   const { profile } = useProfileInfo();
-  const artworks = usePortfolio(profile.id);
+  const artworks = usePortfolio(profile?.id);
   const history = useHistory();
   return (
     <article className="Portfolio">


### PR DESCRIPTION
## Changes
- Added a green color to visited artwork on the Art Map Page. Includes green map pins, stars on the `ArtChoices` component, and an "View in Portfolio" button on `ArtInfo`.
- On large, the `TabBar` component is fixed to the bottom of the screen, instead of having a bug where it doesn't remain attached on scroll.
- The `useProfileInfo` hook now updates correctly with super rapid calls to `setUser`
- Took out a few unused components on `ArtSubmission` page.

## Testing
Mainly the first bullet in the section above. I also ensured that loading each page straight from the url doesn't cause the app to crash.
1. Go to the Map page.
2. Ensure that stuff shows up in green and nothing crashes :)