### PR TITLE
Generalized Discussion Page

### DIFF
--- a/backend/mutations.py
+++ b/backend/mutations.py
@@ -375,6 +375,27 @@ class DiscussionCommentMutation(graphene.Mutation):
     artwork.save()
     return DiscussionCommentMutation(comment=c)
 
+  
+class GroupDiscussionCommentMutation(graphene.Mutation):
+  """
+  Adds a comment to the group page of an artwork.
+  """
+  class Arguments:
+      group_id = graphene.ID(required=True)
+      comment = CommentInput(required=True)
+  
+  comment = graphene.Field(CommentType)
+
+  def mutate(self, info, group_id=None, comment=None ):
+    # Find the user and the artwork and create a new comment.
+    
+    group: Group = Group.objects.get(pk=decodeId(group_id))
+    user : User = User.objects.get(pk=decodeId(comment.author))
+    c = Comment(author=user, content=comment.content)
+    group.chat.append(c)
+    group.save()
+    return GroupDiscussionCommentMutation(comment=c)
+
 
 
 class UpdateArtworkMutation(graphene.Mutation):

--- a/backend/schema.py
+++ b/backend/schema.py
@@ -2,7 +2,7 @@ import graphene
 from graphene.relay import Node
 from mutations import UpdateUserMutation, CreateUserMutation, DeleteUserMutation, CreateArtworkMutation, UpdateArtworkMutation
 from mutations import DeleteArtworkMutation, CreateGroupMutation, UpdateGroupMutation, CreateAchievementMutation, CreateReportMutation
-from mutations import AddArtworkReviewMutation, DiscussionCommentMutation
+from mutations import AddArtworkReviewMutation, DiscussionCommentMutation, GroupDiscussionCommentMutation
 from api_types import UserType, PortfolioType, ArtworkType, AchievementType, GroupType, ReportType
 from graphene_mongo import MongoengineConnectionField
 from models import Artwork
@@ -32,6 +32,7 @@ class Mutations(graphene.ObjectType):
     delete_artwork = DeleteArtworkMutation.Field()
     add_artwork_review = AddArtworkReviewMutation.Field()
     add_artwork_comment = DiscussionCommentMutation.Field()
+    add_group_comment = GroupDiscussionCommentMutation.Field()
 
     create_group = CreateGroupMutation.Field()
     update_group = UpdateGroupMutation.Field()

--- a/backend/testing.py
+++ b/backend/testing.py
@@ -6,6 +6,7 @@ import base64
 import os
 import random
 from typing import List
+import datetime
 
 
 def testing_boot_up():
@@ -418,8 +419,17 @@ def get_comments(num_comments:int, users: List[User]) -> List[Comment]:
         "I started painting as a hobby when I was little. I didn’t know I had any talent. I believe talent is just a pursued interest. Anybody can do what I do."
     ]
 
-
-    comments = [Comment(author=random.choice(users), content=random.choice(content_lib)) for x in range(num_comments)]
+    start_date = datetime.date(2020, 1, 1)
+    end_date = datetime.datetime.now().date()
+    time_between_dates = end_date - start_date
+    
+    comments = []
+    for _ in range(num_comments):
+        random_number_of_days = random.randrange(time_between_dates.days)
+        rand_date = start_date + datetime.timedelta(days=random_number_of_days)
+        rand_datetime = datetime.datetime.combine(rand_date, datetime.datetime.min.time())
+        comment = Comment(author=random.choice(users), content=random.choice(content_lib), date_posted=rand_datetime)
+        comments.append(comment)
     return comments
 
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,7 +2,6 @@ import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import ArtMap from "./pages/ArtMap/ArtMap";
 import Camera from "./pages/Camera/Camera";
 import Artwork from "./pages/Artwork/Artwork";
-import Discussion from "./pages/Artwork/components/Discussion/Discussion";
 import StyleGuide from "./components/StyleGuide";
 import ArtSubmission from "./pages/ArtSubmission/ArtSubmission";
 import { UserPortfolio } from "./pages/Portfolio/Portfolio";
@@ -33,11 +32,6 @@ function App() {
             <Route exact path="/map/:artwork/track" component={ArtMap} />
             <Route exact path="/artwork/:id/report" component={ReportArtwork} />
             <Route path="/artwork/:id" component={Artwork} />
-            <Route
-              exact
-              path="/artwork/:id/discussion"
-              component={Discussion}
-            />
             <Route path="/camera" component={Camera} />
             <Route path="/art-submission" component={ArtSubmission} />
 

--- a/frontend/src/components/MetricBadge/MetricBadge.tsx
+++ b/frontend/src/components/MetricBadge/MetricBadge.tsx
@@ -1,11 +1,17 @@
 import "./MetricBadge.scss";
 
+interface MetricBadgeProps {
+  value: string | number,
+  unit: string,
+  fallbackVal?: string | number
+}
+
 export default function MetricBadge({
   value,
   unit,
   fallbackVal,
   ...restProps
-}) {
+}: MetricBadgeProps) {
   return (
     <div className="MetricBadge" {...restProps}>
       <p className="value">{value ?? fallbackVal}</p>

--- a/frontend/src/components/Spinner/Spinner.tsx
+++ b/frontend/src/components/Spinner/Spinner.tsx
@@ -1,13 +1,14 @@
 import "./Spinner.scss"
 import React from "react"
 
-type SpinnerProps = {
-  style : React.CSSProperties,
-  className: string
+interface SpinnerProps {
+  style? : React.CSSProperties,
+  className?: string,
+  absCenter?: boolean
 }
 
 export default function Spinner(props: SpinnerProps) {
-
-  return <div className={["Spinner", props.className].join(" ")} style={props.style}>
+  const classNames = ["Spinner", props.className, props.absCenter && "absolute-center"].filter(v => v).join(" ")
+  return <div className={classNames} style={props.style}>
   </div>;
 }

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -1,0 +1,25 @@
+interface DiscussionComment {
+  author: String;
+  content: String;
+  datePosted: Date;
+}
+
+type GqlCommentData = {
+  content: string;
+  datePosted: string;
+  author: {
+    name: string;
+  };
+};
+
+interface GqlArtworkData {
+  pictures: string[];
+  title: string;
+  description: string;
+  tags: string[];
+  id: string;
+  metrics: {
+    totalVisits: number;
+  };
+  rating: number;
+}

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -1,6 +1,6 @@
 interface DiscussionComment {
-  author: String;
-  content: String;
+  author: string;
+  content: string;
   datePosted: Date;
 }
 

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -129,6 +129,13 @@ code {
     monospace;
 }
 
+.absolute-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
 #App {
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/Artwork/Artwork.tsx
+++ b/frontend/src/pages/Artwork/Artwork.tsx
@@ -21,7 +21,7 @@ import MetricBadge from "../../components/MetricBadge/MetricBadge";
 import Tag from "../../components/Tag/Tag";
 import ConnectionErrorMessage from "../../components/ConnectionErrorMessage/ConnectionErrorMessage";
 import { useParams, useHistory, Route, Switch } from "react-router-dom";
-import { gql, useQuery } from "@apollo/client";
+import { useQuery } from "@apollo/client";
 
 export default function Artwork() {
   const { goBack, push } = useHistory();
@@ -119,7 +119,12 @@ export default function Artwork() {
         <ArtReview artwork={artwork} />
       </Route>
       <Route exact path="/artwork/:id/discussion">
-        <Discussion fetchQuery={GET_ARTWORK_DISCUSSION} fetchVariables={{id}} commentResolver={artCommentResolver} postMutation={POST_DISCUSSION_MESSAGE} postResolver={artPostResolver} />
+        <Discussion 
+        fetchQuery={GET_ARTWORK_DISCUSSION} 
+        fetchVariables={{id}} 
+        commentResolver={artCommentResolver} 
+        postMutation={POST_DISCUSSION_MESSAGE} 
+        postResolver={artPostResolver} />
       </Route>
     </Switch>
   );

--- a/frontend/src/pages/Artwork/Artwork.tsx
+++ b/frontend/src/pages/Artwork/Artwork.tsx
@@ -10,7 +10,13 @@ import {
 } from "react-feather";
 
 import ArtReview from "../ArtReview/ArtReview";
-
+import Discussion from "../Discussion/Discussion";
+import {
+  GET_ARTWORK_DISCUSSION,
+  POST_DISCUSSION_MESSAGE,
+  GET_ARTWORK, 
+  artCommentResolver,
+  ArtworkQueryData} from "./gql"
 import MetricBadge from "../../components/MetricBadge/MetricBadge";
 import Tag from "../../components/Tag/Tag";
 import ConnectionErrorMessage from "../../components/ConnectionErrorMessage/ConnectionErrorMessage";
@@ -19,33 +25,19 @@ import { gql, useQuery } from "@apollo/client";
 
 export default function Artwork() {
   const { goBack, push } = useHistory();
-  const { id } = useParams();
-  const query = gql`
-    query getArtwork($id: ID!) {
-      artwork(id: $id) {
-        edges {
-          node {
-            pictures
-            title
-            description
-            tags
-            id
-            metrics {
-              totalVisits
-            }
-            rating
-          }
-        }
-      }
-    }
-  `;
+  const { id } = useParams<{id: string}>();
+  
 
-  const { loading, error, data } = useQuery(query, { variables: { id } });
+
+
+  
+
+  const { loading, error, data } = useQuery<ArtworkQueryData>(GET_ARTWORK, { variables: { id } });
 
   if (loading) return <h1>Loading...</h1>;
-  if (error)
+  if (error || !data)
     return (
-      <ConnectionErrorMessage>Error: {error.message}</ConnectionErrorMessage>
+      <ConnectionErrorMessage>Could not access the artwork you requested.</ConnectionErrorMessage>
     );
 
   const artwork = data.artwork.edges[0]?.node;
@@ -63,6 +55,10 @@ export default function Artwork() {
   ];
 
   const pic_src = artwork.pictures[0];
+
+  function artPostResolver(postInfo: {message: string, author: string}) {
+    return {content: postInfo.message, author: postInfo.author, id }
+  }
 
   return (
     <Switch>
@@ -121,6 +117,9 @@ export default function Artwork() {
       </Route>
       <Route exact path="/artwork/:id/art-review">
         <ArtReview artwork={artwork} />
+      </Route>
+      <Route exact path="/artwork/:id/discussion">
+        <Discussion fetchQuery={GET_ARTWORK_DISCUSSION} fetchVariables={{id}} commentResolver={artCommentResolver} postMutation={POST_DISCUSSION_MESSAGE} postResolver={artPostResolver} />
       </Route>
     </Switch>
   );

--- a/frontend/src/pages/Artwork/gql.ts
+++ b/frontend/src/pages/Artwork/gql.ts
@@ -1,0 +1,97 @@
+import { gql } from "@apollo/client";
+
+export const GET_ARTWORK_DISCUSSION = gql`
+  query getDiscussion($id: ID!) {
+    artwork(id: $id) {
+      edges {
+        node {
+          pictures
+          comments {
+            edges {
+              node {
+                content
+                datePosted
+                author {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const POST_DISCUSSION_MESSAGE = gql`
+  mutation postMessage($id: ID!, $content: String!, $author: ID!) {
+    addArtworkComment(
+      artworkId: $id
+      comment: { content: $content, author: $author }
+    ) {
+      comment {
+        content
+      }
+    }
+  }
+`;
+
+export const GET_ARTWORK = gql`
+  query getArtwork($id: ID!) {
+    artwork(id: $id) {
+      edges {
+        node {
+          pictures
+          title
+          description
+          tags
+          id
+          metrics {
+            totalVisits
+          }
+          rating
+        }
+      }
+    }
+  }
+`;
+
+export interface ArtworkQueryData {
+  artwork: {
+    edges: {
+      node: GqlArtworkData;
+    }[];
+  };
+}
+
+interface ArtworkCommentData {
+  artwork: {
+    edges: {
+      node: {
+        pictures: string[];
+        comments: {
+          edges: {
+            node: GqlCommentData;
+          }[];
+        };
+      };
+    }[];
+  };
+}
+
+/**
+ * Handles retrieving artwork comments from the server.
+ */
+export function artCommentResolver(
+  data: ArtworkCommentData | undefined
+): { picture: string; comments: DiscussionComment[] } {
+  const comments: DiscussionComment[] | undefined = !data
+    ? []
+    : data.artwork.edges?.[0].node.comments.edges.map(({ node }) => ({
+        content: node.content,
+        author: node.author.name,
+        datePosted: new Date(node.datePosted),
+      }));
+  const picture = !data ? "" : data.artwork.edges?.[0].node.pictures[0];
+  return { comments, picture };
+}

--- a/frontend/src/pages/Artwork/gql.ts
+++ b/frontend/src/pages/Artwork/gql.ts
@@ -80,7 +80,7 @@ interface ArtworkCommentData {
 }
 
 /**
- * Handles retrieving artwork comments from the server.
+ * Turns gql data into a list of comments and an image.
  */
 export function artCommentResolver(
   data: ArtworkCommentData | undefined

--- a/frontend/src/pages/Artwork/gql.ts
+++ b/frontend/src/pages/Artwork/gql.ts
@@ -87,11 +87,14 @@ export function artCommentResolver(
 ): { picture: string; comments: DiscussionComment[] } {
   const comments: DiscussionComment[] | undefined = !data
     ? []
-    : data.artwork.edges?.[0].node.comments.edges.map(({ node }) => ({
-        content: node.content,
-        author: node.author.name,
-        datePosted: new Date(node.datePosted),
-      }));
+    : data.artwork.edges?.[0].node.comments.edges.map(({ node }) => {
+        return {
+          content: node.content,
+          author: node.author.name,
+          datePosted: new Date(node.datePosted),
+        };
+      });
   const picture = !data ? "" : data.artwork.edges?.[0].node.pictures[0];
+  comments.sort((a, b) => a.datePosted.getTime() - b.datePosted.getTime());
   return { comments, picture };
 }

--- a/frontend/src/pages/Discussion/Discussion.scss
+++ b/frontend/src/pages/Discussion/Discussion.scss
@@ -1,4 +1,4 @@
-@use "../../../../styles/utils" as theme;
+@use "../../styles/utils.scss" as theme;
 
 .Discussion {
   overflow: hidden;

--- a/frontend/src/pages/Groups/GroupPage/gql.ts
+++ b/frontend/src/pages/Groups/GroupPage/gql.ts
@@ -1,0 +1,138 @@
+import { gql } from "@apollo/client";
+
+export const GET_GROUP_QUERY = gql`
+  query getGroup($id: ID!) {
+    groups(id: $id) {
+      edges {
+        node {
+          name
+          bio
+          metrics {
+            artworkCount
+            memberCount
+          }
+          groupPortfolio {
+            artworks(first: 7) {
+              edges {
+                node {
+                  id
+                  title
+                  pictures
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const GET_COMMENTS_QUERY = gql`
+  query getComments($id: ID!) {
+    groups(id: $id) {
+      edges {
+        node {
+          chat {
+            edges {
+              node {
+                content
+                datePosted
+                author {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const POST_DISCUSSION_MESSAGE = gql`
+  mutation postMessage($id: ID!, $content: String!, $author: ID!) {
+    addGroupComment(
+      groupId: $id
+      comment: { content: $content, author: $author }
+    ) {
+      comment {
+        content
+      }
+    }
+  }
+`;
+
+export interface GqlGroupData {
+  groups: {
+    edges: {
+      node: {
+        name: string;
+        bio: string;
+        metrics: {
+          artworkCount: number;
+          memberCount: number;
+        };
+        groupPortfolio: {
+          artworks: {
+            edges: {
+              node: {
+                id: string;
+                title: string;
+                pictures: string[];
+              };
+            }[];
+          };
+        };
+      };
+    }[];
+  };
+}
+
+interface Artwork {
+  title: string;
+  pictures: string[];
+  id: string;
+}
+
+interface Group {
+  name: string;
+  bio: string;
+  metrics: {
+    artworkCount: number;
+    memberCount: number;
+  };
+  artworks: Artwork[];
+}
+
+export function groupResolver(data: GqlGroupData): Group | undefined {
+  const group = data?.groups.edges?.[0].node;
+  const artworks: Artwork[] = group?.groupPortfolio.artworks.edges.map(
+    ({ node }: { node: Artwork }) => ({
+      title: node.title,
+      pictures: node.pictures,
+      id: node.id,
+    })
+  );
+  return (
+    group && {
+      name: group.name,
+      bio: group.bio,
+      metrics: group.metrics,
+      artworks,
+    }
+  );
+}
+
+export function groupCommentsResolver(
+  data: any
+): { comments: DiscussionComment[]; picture?: string } {
+  const comments: DiscussionComment[] = !data
+    ? []
+    : data.groups.edges?.[0].node.chat.edges.map(({ node }: { node: any }) => ({
+        content: node.content,
+        author: node.author.name,
+        datePosted: new Date(node.datePosted),
+      }));
+  return { comments };
+}

--- a/frontend/src/pages/Groups/GroupsList/GroupsList.jsx
+++ b/frontend/src/pages/Groups/GroupsList/GroupsList.jsx
@@ -45,31 +45,23 @@ export default function GroupsList() {
   function openGroup(id) {
     history.push("group/" + id);
   }
-
+  if (loading) return <Spinner absCenter={true} />;
+  if (!groups.length)
+    return (
+      <ConnectionErrorMessage>
+        Doesn't look like you've joined any groups
+      </ConnectionErrorMessage>
+    );
   return (
     <article className="GroupsList">
       <header>
         <h1>Groups</h1>
       </header>
-      {loading ? (
-        <div className="spinner">
-          <Spinner />
-        </div>
-      ) : groups.length ? (
-        <ul className="groups">
-          {groups.map((group, key) => (
-            <GroupCard
-              key={key}
-              {...group}
-              onClick={() => openGroup(group.id)}
-            />
-          ))}
-        </ul>
-      ) : (
-        <ConnectionErrorMessage>
-          Doesn't look like you've joined any groups
-        </ConnectionErrorMessage>
-      )}
+      <ul className="groups">
+        {groups.map((group, key) => (
+          <GroupCard key={key} {...group} onClick={() => openGroup(group.id)} />
+        ))}
+      </ul>
     </article>
   );
 }

--- a/frontend/src/pages/Groups/GroupsList/GroupsList.scss
+++ b/frontend/src/pages/Groups/GroupsList/GroupsList.scss
@@ -71,11 +71,4 @@
       }
     }
   }
-
-  .spinner {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-  }
 }

--- a/frontend/src/pages/ReportArtwork/ReportArtwork.jsx
+++ b/frontend/src/pages/ReportArtwork/ReportArtwork.jsx
@@ -46,7 +46,6 @@ export default function ArtSubmission() {
   const { profile } = useProfileInfo();
   const { id } = useParams();
 
-  //onSubmit function is passed to handleSubmit function
   function onSubmit(data) {
     const payload = {
       reportedIdType: "report",
@@ -56,8 +55,6 @@ export default function ArtSubmission() {
       description: data.description,
     };
 
-    //debugger
-    //console.log(payload)
     submitReport({ variables: payload }).then((res) => {
       history.push("/artwork/" + id);
     });


### PR DESCRIPTION
Fixes #105 and #90

**The discussion page is now general enough to use as a comment UI anywhere in the app**

## Changes
- Created a `Discussion` component that can be plugged into any GraphQL interface in the app.
- Added an `addGroupComment` mutation to the backend.
- Updated the spinner with `absCenter` prop to easily center the spinner in the page.
- Broke out GraphQL resolvers, queries and mutations to localized `gql.ts` files on the frontend.
- Fixed polling issue with `Discussion` page.

## New Discussion Setup

> TL;DR: Pass the GQL endpoints into the discussion post and use resolver functions to get the data in the correct formats.

So the new discussion component is a bit weird, so this is the reasoning behind the design. We want the Discussion page to work in a variety of contexts with different paths to fetch and post comments, but logically it would be nice if we didn't have to pollute the parent scope with discussion specific logic. To keep the state in the Discussion component and still have complete flexibility, I had to divide the process of fetching and posting into two parts:
- **Request**: The actual query or mutation that changes the data
- **Resolver**: A function that takes the incoming or outgoing data and reformats it into an agreed upon standard.

For example, for the artwork page, we pass in the query to get the discussion:
```
artwork(id: $id) {
      edges {
        node {
          pictures
          comments {
            edges {
              node {
                content
                datePosted
                author {
                  name
                }
              }
            }
          }
        }
      }
    }
  }
```

and the resolver will run on this nested data to turn it into this:
```
{
  author: string;
  content: string;
  datePosted: Date;
}[]
```

## Testing:
1. With both servers running, go to an artwork in your portfolio.
2. Click on the chat button at the bottom of the page.
3. Type in a message and hit enter
4. Ensure the message appears on screen
5. Exit out and check in the backend server console session that repeated polling stops.
6. Go back into the chat and ensure that your message is still there.
7. Go to the group list
8. Click on a group.
9. On the group page, click on the chat button at the top right.
10. Ensure that the chat page comes up.