### PR TITLE
Login

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python 3.8.9
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8.9
+          python-version: 3.8.*
       - name: Install pipenv
         run: pip install pipenv
       - name: Go into backend folder, create virtual environent, and run testing

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.8.9
+      - name: Set up Python 3.8.*
         uses: actions/setup-python@v1
         with:
           python-version: 3.8.*

--- a/backend/mutations.py
+++ b/backend/mutations.py
@@ -27,6 +27,7 @@ def decodeId(id):
     type_and_id = str(decoded)[2:-1].split(":")
     return type_and_id[1]
 
+
 def checkAchievements(user):
     achievements = Achievement.objects
     achievements_to_add = []
@@ -209,6 +210,7 @@ class UserInput(graphene.InputObjectType):
 class CreateUserMutation(graphene.Mutation):
     # possible output types to show with return query
     user = graphene.Field(UserType)
+    success = graphene.Boolean()
 
     class Arguments:
         user_data = UserInput(required=True)
@@ -218,23 +220,26 @@ class CreateUserMutation(graphene.Mutation):
         settings = Settings()
         metrics = UserMetrics()
         
-        user = User(
-            # Need to eventually add username (if that's not the 'name') and password
-            name = user_data.name,
-            bio = user_data.bio,    # not required by model, will assume frontend filters input
-            email = user_data.email,
-            password = user_data.password,
-            profile_pic = user_data.profile_pic,
-            metrics = metrics,
-            achievements = [], # will likely want to add a hard coded initial achievement
-            personal_portfolio = portfolio,
-            groups = [],
-            settings = settings
-        )
-        checkAchievements(user)
-        user.save()
+        try:
+            user = User.objects.get(pk=user_data.email)
+        except Exception as e: # email not taken
+            user = User(
+                name = user_data.name,
+                bio = user_data.bio,
+                email = user_data.email,
+                password = user_data.password,
+                profile_pic = user_data.profile_pic,
+                metrics = metrics,
+                achievements = [],
+                personal_portfolio = portfolio,
+                groups = [],
+                settings = settings
+            )
+            checkAchievements(user)
+            user.save()
+            return CreateUserMutation(user=user, success=True)
 
-        return CreateUserMutation(user=user)
+        return CreateUserMutation(user=None, success=False)
 
 # Querying by id as an "id" argument should be by encoded string
 # id within user_input will be the primary key (email right now)
@@ -524,6 +529,29 @@ class CreateReportMutation(graphene.Mutation):
 
         return CreateReportMutation(report=report)
 
+
+class AuthenticateUserMutation(graphene.Mutation):
+    user = graphene.Field(UserType)
+    success = graphene.Boolean()
+
+    class Arguments:
+        email = graphene.String()
+        password = graphene.String()
+
+    def mutate(self, info, email, password):
+        
+        def cryptPassword(password):
+            return password
+        
+        try:
+            user = User.objects.get(pk=email)
+        except Exception as e:
+            return AuthenticateUserMutation(user=None, success=False)
+
+        if cryptPassword(password) != user.password:
+            return AuthenticateUserMutation(user=None, success=False)
+
+        return AuthenticateUserMutation(user=user, success=True)
 
 
 ''' 

--- a/backend/schema.py
+++ b/backend/schema.py
@@ -2,7 +2,7 @@ import graphene
 from graphene.relay import Node
 from mutations import UpdateUserMutation, CreateUserMutation, DeleteUserMutation, CreateArtworkMutation, UpdateArtworkMutation
 from mutations import DeleteArtworkMutation, CreateGroupMutation, UpdateGroupMutation, CreateAchievementMutation, CreateReportMutation
-from mutations import AddArtworkReviewMutation, DiscussionCommentMutation
+from mutations import AddArtworkReviewMutation, DiscussionCommentMutation, AuthenticateUserMutation
 from api_types import UserType, PortfolioType, ArtworkType, AchievementType, GroupType, ReportType
 from graphene_mongo import MongoengineConnectionField
 from models import Artwork
@@ -26,6 +26,7 @@ class Mutations(graphene.ObjectType):
     create_user = CreateUserMutation.Field()
     update_user = UpdateUserMutation.Field()
     delete_user = DeleteUserMutation.Field()
+    authenticate_user = AuthenticateUserMutation.Field()
 
     create_artwork = CreateArtworkMutation.Field()
     update_artwork = UpdateArtworkMutation.Field()

--- a/backend/schema.py
+++ b/backend/schema.py
@@ -2,7 +2,7 @@ import graphene
 from graphene.relay import Node
 from mutations import UpdateUserMutation, CreateUserMutation, DeleteUserMutation, CreateArtworkMutation, UpdateArtworkMutation
 from mutations import DeleteArtworkMutation, CreateGroupMutation, UpdateGroupMutation, CreateAchievementMutation, CreateReportMutation
-from mutations import AddArtworkReviewMutation, DiscussionCommentMutation, GroupDiscussionCommentMutation
+from mutations import AddArtworkReviewMutation, DiscussionCommentMutation, GroupDiscussionCommentMutation, AuthenticateUserMutation
 from api_types import UserType, PortfolioType, ArtworkType, AchievementType, GroupType, ReportType
 from graphene_mongo import MongoengineConnectionField
 from models import Artwork
@@ -26,6 +26,7 @@ class Mutations(graphene.ObjectType):
     create_user = CreateUserMutation.Field()
     update_user = UpdateUserMutation.Field()
     delete_user = DeleteUserMutation.Field()
+    authenticate_user = AuthenticateUserMutation.Field()
 
     create_artwork = CreateArtworkMutation.Field()
     update_artwork = UpdateArtworkMutation.Field()

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ import ReportArtwork from "./pages/ReportArtwork/ReportArtwork";
 import TabBar from "./components/TabBar/TabBar";
 import useProfileInfo from "./hooks/useProfileInfo";
 import NewAccount from "./pages/SignUp/SignUp";
+import Login from "./pages/Login/Login";
 import { useEffect } from "react";
 
 const userId = "VXNlclR5cGU6am9obkBqb2huLmNvbQ==";
@@ -41,6 +42,7 @@ function App() {
             <Route path="/group/:id" component={GroupPage} />
             <Route path="/style-guide" component={StyleGuide} />
             <Route path="/sign-up" component={NewAccount} />
+            <Route path="/login" component={Login} />
             <Route path="*" component={ArtMap} />
           </Switch>
         </div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,7 @@ import ReportArtwork from "./pages/ReportArtwork/ReportArtwork";
 import TabBar from "./components/TabBar/TabBar";
 import useProfileInfo from "./hooks/useProfileInfo";
 import NewAccount from "./pages/NewAccount/NewAccount";
+import Login from "./pages/Login/Login";
 import { useEffect } from "react";
 
 const userId = "VXNlclR5cGU6am9obkBqb2huLmNvbQ==";
@@ -47,6 +48,7 @@ function App() {
             <Route path="/group/:id" component={GroupPage} />
             <Route path="/style-guide" component={StyleGuide} />
             <Route path="/new-account" component={NewAccount} />
+            <Route path="/login" component={Login} />
             <Route path="*" component={ArtMap} />
           </Switch>
         </div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,7 @@ import ReportArtwork from "./pages/ReportArtwork/ReportArtwork";
 import TabBar from "./components/TabBar/TabBar";
 import useProfileInfo from "./hooks/useProfileInfo";
 import NewAccount from "./pages/SignUp/SignUp";
+import Login from "./pages/Login/Login";
 import { useEffect } from "react";
 
 const userId = "VXNlclR5cGU6am9obkBqb2huLmNvbQ==";
@@ -47,6 +48,7 @@ function App() {
             <Route path="/group/:id" component={GroupPage} />
             <Route path="/style-guide" component={StyleGuide} />
             <Route path="/sign-up" component={NewAccount} />
+            <Route path="/login" component={Login} />
             <Route path="*" component={ArtMap} />
           </Switch>
         </div>

--- a/frontend/src/graphql-config.js
+++ b/frontend/src/graphql-config.js
@@ -2,7 +2,7 @@ import { ApolloClient, InMemoryCache } from "@apollo/client";
 const uri =
   process.env.NODE_ENV === "production"
     ? "https://csc-309-geoart.herokuapp.com/graphql?"
-    : "http://0.0.0.0:8080/graphql?";
+    : "http://localhost:8080/graphql?";
 export const client = new ApolloClient({
   uri, // We will change this for production
   cache: new InMemoryCache(),

--- a/frontend/src/pages/Login/Login.jsx
+++ b/frontend/src/pages/Login/Login.jsx
@@ -1,0 +1,84 @@
+import "./Login.scss";
+
+import { useMutation, gql } from "@apollo/client";
+import { useForm } from "react-hook-form";
+import { useHistory } from "react-router-dom";
+import useProfileInfo from "../../hooks/useProfileInfo";
+
+const GET_USER_MUTATION = gql`
+  mutation getUser($email: String!, $password: String!) {
+    authenticateUser(userData: { email: $email, password: $password }) {
+      user {
+        id
+      }
+    }
+  }
+`;
+
+
+
+export default function Login() {
+  const { setUser } = useProfileInfo(); 
+  const { push } = useHistory();
+
+  const { register, handleSubmit } = useForm();
+
+  const [userLogin] = useMutation(GET_USER_MUTATION);
+
+  async function onSubmit(data) {
+    // If encrypting, we would encrypt the password here
+    const payload = {
+      email: data.email,
+      password: data.password
+    };
+
+    let login = await userLogin({variables: payload});
+
+    debugger;
+
+    console.log(login.data)
+    console.log(login.error)
+    console.log(login.loading)
+
+    //setUser(resp.data.createUser.user.id);
+    //push("/profile");
+  }
+
+  return (
+    <article className="Login">
+      <header>
+        <h2>Log In</h2>
+      </header>
+
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <div className="input">
+          <label htmlFor="email">Email</label>
+          <br />
+          <input
+            type="email"
+            name="email"
+            id="email"
+            ref={register({
+              required: true,
+            })}
+          />
+        </div>
+
+        <div className="input">
+          <label htmlFor="password">Password</label>
+          <br />
+          <input
+            type="password"
+            name="password"
+            id="password"
+            ref={register({
+              required: true,
+            })}
+          />
+        </div>
+
+        <input type="submit" />
+      </form>
+    </article>
+  );
+}

--- a/frontend/src/pages/Login/Login.jsx
+++ b/frontend/src/pages/Login/Login.jsx
@@ -82,7 +82,7 @@ export default function Login() {
       </form>
       <h4>New user?</h4>
       <div>
-        <button onClick={console.log("stop calling me when loading the page")}>Sign Up</button>
+        <button onClick={() => push("/sign-up")}>Sign Up</button>
       </div>
     </article>
   );

--- a/frontend/src/pages/Login/Login.jsx
+++ b/frontend/src/pages/Login/Login.jsx
@@ -7,10 +7,11 @@ import useProfileInfo from "../../hooks/useProfileInfo";
 
 const GET_USER_MUTATION = gql`
   mutation getUser($email: String!, $password: String!) {
-    authenticateUser(userData: { email: $email, password: $password }) {
+    authenticateUser(email: $email, password: $password) {
       user {
         id
       }
+      success
     }
   }
 `;
@@ -27,21 +28,21 @@ export default function Login() {
 
   async function onSubmit(data) {
     // If encrypting, we would encrypt the password here
+    
     const payload = {
       email: data.email,
       password: data.password
     };
 
-    let login = await userLogin({variables: payload});
+    const login = await userLogin({variables: payload});
 
-    debugger;
-
-    console.log(login.data)
-    console.log(login.error)
-    console.log(login.loading)
-
-    //setUser(resp.data.createUser.user.id);
-    //push("/profile");
+    if (login["data"]["authenticateUser"]["success"]) {
+      setUser(login["data"]["authenticateUser"]["user"]["id"]);
+      push("/map");
+    }
+    else {
+      alert("Unrecognized email/password combination.");
+    }
   }
 
   return (
@@ -79,6 +80,10 @@ export default function Login() {
 
         <input type="submit" />
       </form>
+      <h4>New user?</h4>
+      <div>
+        <button onClick={console.log("stop calling me when loading the page")}>Sign Up</button>
+      </div>
     </article>
   );
 }

--- a/frontend/src/pages/Login/Login.scss
+++ b/frontend/src/pages/Login/Login.scss
@@ -31,4 +31,11 @@
       outline: none;
     }
   }
+  h4 {
+    display: inline-block;
+    margin-left: 30px;
+  }
+  button {
+    margin-left: 30px;
+  }
 }

--- a/frontend/src/pages/Login/Login.scss
+++ b/frontend/src/pages/Login/Login.scss
@@ -1,0 +1,34 @@
+.Login {
+
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 30px;
+    box-shadow: var(--shadow-button);
+    margin-bottom: 30px;
+
+    h2 {
+      display: inline-block;
+      margin: 0;
+    }
+  }
+
+  form {
+    margin-left: 30px;
+
+    > * {
+      margin: 0px;
+      margin-bottom: 10px;
+    }
+
+    .input input {
+      padding: 10px;
+    }
+
+    > input {
+      margin-top: 10px;
+      outline: none;
+    }
+  }
+}

--- a/frontend/src/pages/SignUp/SignUp.jsx
+++ b/frontend/src/pages/SignUp/SignUp.jsx
@@ -11,6 +11,7 @@ const NEW_ACCOUNT_MUTATION = gql`
       user {
         id
       }
+      success
     }
   }
 `;
@@ -30,8 +31,13 @@ export default function NewAccount() {
     };
 
     let resp = await submitUser({ variables: payload });
-    setUser(resp.data.createUser.user.id);
-    push("/profile");
+    if (resp.data.createUser.success) {
+      setUser(resp.data.createUser.user.id);
+      push("/map");
+    }
+    else {
+      alert("An account already exists with that email.");
+    }
   }
 
   return (
@@ -82,6 +88,10 @@ export default function NewAccount() {
 
         <input type="submit" />
       </form>
+      <h4>Already have an account?</h4>
+      <div>
+        <button onClick={console.log("stop calling me when loading the page")}>Log In</button>
+      </div>
     </article>
   );
 }

--- a/frontend/src/pages/SignUp/SignUp.jsx
+++ b/frontend/src/pages/SignUp/SignUp.jsx
@@ -90,7 +90,7 @@ export default function NewAccount() {
       </form>
       <h4>Already have an account?</h4>
       <div>
-        <button onClick={console.log("stop calling me when loading the page")}>Log In</button>
+        <button onClick={() => push("/login")}>Log In</button>
       </div>
     </article>
   );

--- a/frontend/src/pages/SignUp/SignUp.scss
+++ b/frontend/src/pages/SignUp/SignUp.scss
@@ -31,4 +31,12 @@
       outline: none;
     }
   }
+
+  h4 {
+    display: inline-block;
+    margin-left: 30px;
+  }
+  button {
+    margin-left: 30px;
+  }
 }


### PR DESCRIPTION
Solves #101  

Login front end and backend complete. Left room for encryption if wanted down the road, but not implemented.
Added duplicate email check for sign-in
Added buttons to go between login and sign-in
Updated yml file to fix python version for github action
Changed "0.0.0.0" link to "localhost" when linking with Apollo locally

I think after this pr we just need to solve the user state issue and then we're good to change the default page to sign in. I guess we could also page a home page, but that's not too necessary.

To test:

Boot up backend and frontend locally
go to "/sign-up" page:
   attempt to sign up with existing email (eg: braden@braden.com) and confirm error response
   sign up normally and verify that you get taken to the map page
go to "/login" page:
   attempt to sign in with the account you just made. Test with bad password and/or bad username
   could also test with (braden@braden.com, "bradeniscool")
   verify on successful login that you go back to map page
try going between either page with buttons