### PR TITLE
GroupPage Artwork Overlap

### DIFF
--- a/frontend/src/pages/Groups/GroupPage/GroupPage.scss
+++ b/frontend/src/pages/Groups/GroupPage/GroupPage.scss
@@ -52,6 +52,7 @@
     border-radius: 100px;
     background-color: white;
     box-shadow: 0 0 15px rgba(0, 0, 0, 0.233);
+    z-index: 1;
 
     svg {
       width: 35px;


### PR DESCRIPTION
Fixes #120 
Artwork cards no longer overlap header options
<img width="620" alt="Screen Shot 2021-05-17 at 3 22 14 PM" src="https://user-images.githubusercontent.com/33008436/118563607-b8607680-b723-11eb-9b7e-8e88591c62e6.png">

## Testing
- Go to group page.
- Shrink the screen so when scrolled the artwork cards and the header options intersect.
- Verify that the header options stay on top.