### PR TITLE
Add Artwork to Group

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -78,6 +78,7 @@ def init_db():
         Portfolio(artworks=[art[2], art[4]]),
         Portfolio(artworks=[art[1], art[2], art[3]]),
         Portfolio(artworks=[art[3], art[5]]),
+        Portfolio(artworks=[art[3]]),
     ]
 
     users = [
@@ -120,13 +121,13 @@ def init_db():
               bio=("Looking for sick art in West Coast cities. "
                    "Group founders are based in SF and we love our style!"),
               members=[users[0], users[1]],
-              group_portfolio=portfolios[0],
+              group_portfolio=portfolios[4],
               metrics=GroupMetrics(artwork_count=2, member_count=2)),
         Group(name="All Art Welcome",
               bio=("We're here for the community, not the categories. "
                    "Lets see how much art we can collect together!"),
               members=[users[2], users[3]],
-              group_portfolio=portfolios[1],
+              group_portfolio=portfolios[4],
               metrics=GroupMetrics(artwork_count=2, member_count=2))
     ]
 

--- a/backend/testing.py
+++ b/backend/testing.py
@@ -439,7 +439,7 @@ def get_sample_encoded_art_image(filepath="") -> str:
     if filepath == "":
         # select random image if not supplied with a path
         path = "./assets/sample-artworks"
-        image_paths = os.listdir(path)
+        image_paths = [img for img in os.listdir(path) if img.endswith(".jpg")]
         filepath = os.path.join(path, random.choice(image_paths))
     return b64_encode_image(filepath)
 

--- a/frontend/src/components/Drawer/Drawer.scss
+++ b/frontend/src/components/Drawer/Drawer.scss
@@ -1,0 +1,25 @@
+.Drawer {
+  .backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: black;
+  }
+
+  .drawer-wrapper {
+    padding: 15px 35px;
+    background-color: white;
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    width: 300px;
+    max-width: 100%;
+    transform: translateX(-50%);
+
+    h2 {
+      margin: 5px 0;
+    }
+  }
+}

--- a/frontend/src/components/Drawer/Drawer.scss
+++ b/frontend/src/components/Drawer/Drawer.scss
@@ -9,14 +9,21 @@
   }
 
   .drawer-wrapper {
+    position: relative;
     padding: 15px 35px;
     background-color: white;
     position: absolute;
     bottom: 0;
     left: 50%;
     width: 300px;
+    min-height: 200px;
     max-width: 100%;
     transform: translateX(-50%);
+
+    .drawer-content {
+      max-height: 200px;
+      overflow-y: scroll;
+    }
 
     h2 {
       margin: 5px 0;

--- a/frontend/src/components/Drawer/Drawer.tsx
+++ b/frontend/src/components/Drawer/Drawer.tsx
@@ -1,0 +1,30 @@
+import "./Drawer.scss";
+import { motion } from "framer-motion";
+interface DrawerProps {
+  title?: string;
+  children?: React.ReactNode;
+  onClose: () => void;
+}
+
+export default function Drawer(props: DrawerProps) {
+  return (
+    <motion.div className="Drawer">
+      <motion.div
+        className="backdrop"
+        onClick={props.onClose}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 0.3 }}
+        exit={{ opacity: 0 }}
+      ></motion.div>
+      <motion.div
+        className="drawer-wrapper"
+        initial={{ y: "120%", x: "-50%" }}
+        animate={{ y: 0, x: "-50%" }}
+        exit={{ y: "120%", x: "-50%" }}
+      >
+        {props.title && <h2>{props.title}</h2>}
+        {props.children}
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/frontend/src/components/Drawer/Drawer.tsx
+++ b/frontend/src/components/Drawer/Drawer.tsx
@@ -23,7 +23,7 @@ export default function Drawer(props: DrawerProps) {
         exit={{ y: "120%", x: "-50%" }}
       >
         {props.title && <h2>{props.title}</h2>}
-        {props.children}
+        <div className="drawer-content">{props.children}</div>
       </motion.div>
     </motion.div>
   );

--- a/frontend/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -31,7 +31,6 @@ export default function ProtectedRoute({
             children
           );
         } else {
-          console.log(shouldRender ?? auth.currentUser());
           return <Redirect exact to={redirectPath} />;
         }
       }}

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -101,6 +101,10 @@ input[type="submit"] {
     }
   }
 
+  &.danger {
+    background-color: var(--c-problem);
+  }
+
   &:disabled {
     opacity: 0.7;
   }

--- a/frontend/src/pages/Artwork/Artwork.scss
+++ b/frontend/src/pages/Artwork/Artwork.scss
@@ -65,4 +65,21 @@
       }
     }
   }
+
+  .drawer-button {
+    display: block;
+    padding: 5px;
+    margin: 5px 0;
+    background-color: transparent;
+    color: black;
+    font-weight: 400;
+    width: 100%;
+    text-align: left;
+    transition: all 0.3s;
+    border-radius: 0;
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.1);
+    }
+  }
 }

--- a/frontend/src/pages/Artwork/Artwork.tsx
+++ b/frontend/src/pages/Artwork/Artwork.tsx
@@ -170,7 +170,7 @@ function GroupDrawer({ onClose, artworkId }: GroupDrawerProps) {
   function onGroupClick(groupId: string) {
     addArtworkToGroup({
       variables: { artworkId, groupId },
-    }).catch(console.log);
+    }).catch(console.error);
     onClose();
   }
 

--- a/frontend/src/pages/Artwork/Artwork.tsx
+++ b/frontend/src/pages/Artwork/Artwork.tsx
@@ -7,6 +7,7 @@ import {
   MessageSquare,
   AlertCircle,
   Camera,
+  Users,
 } from "react-feather";
 
 import ArtReview from "../ArtReview/ArtReview";
@@ -24,11 +25,14 @@ import ConnectionErrorMessage from "../../components/ConnectionErrorMessage/Conn
 import { useParams, useHistory, Route, Switch } from "react-router-dom";
 import { useQuery } from "@apollo/client";
 import Spinner from "../../components/Spinner/Spinner";
+import Drawer from "../../components/Drawer/Drawer";
+import { useState } from "react";
+import { AnimatePresence } from "framer-motion";
 
 export default function Artwork() {
   const { goBack, push } = useHistory();
   const { id } = useParams<{ id: string }>();
-
+  const [showGroupDrawer, setShowGroupDrawer] = useState(false);
   const { loading, error, data } = useQuery<ArtworkQueryData>(GET_ARTWORK, {
     variables: { id },
   });
@@ -112,8 +116,16 @@ export default function Artwork() {
               <button>
                 <Camera />
               </button>
+              <button onClick={() => setShowGroupDrawer(true)}>
+                <Users />
+              </button>
             </div>
           </div>
+          <AnimatePresence>
+            {showGroupDrawer && (
+              
+            )}
+          </AnimatePresence>
         </article>
       </Route>
       <Route exact path="/artwork/:id/art-review">
@@ -130,4 +142,20 @@ export default function Artwork() {
       </Route>
     </Switch>
   );
+}
+
+
+interface GroupDrawerProps {
+  onClose: () => void
+}
+
+function GroupDrawer(props: GroupDrawerProps) {
+  const {data} = useQuery()
+  return <Drawer
+  title="Choose Group"
+  onClose={props.onClose}
+>
+  <button className="drawer-button">Test</button>
+  <button className="drawer-button">Test</button>
+</Drawer>
 }

--- a/frontend/src/pages/Artwork/gql.ts
+++ b/frontend/src/pages/Artwork/gql.ts
@@ -95,8 +95,8 @@ export function groupOptionsResolver(data: any): GroupOption[] {
 }
 
 export const ADD_ARTWORK_TO_GROUP = gql`
-  mutation addArtworkToGroup($artworkId: ID!, $groupId: ID!) {
-    updateGroup(groupData: { id: $groupId, artToAdd: $groupId }) {
+  mutation addArtworkToGroup($artworkId: String!, $groupId: String!) {
+    updateGroup(groupData: { id: $groupId, artToAdd: $artworkId }) {
       group {
         id
       }

--- a/frontend/src/pages/Artwork/gql.ts
+++ b/frontend/src/pages/Artwork/gql.ts
@@ -56,6 +56,26 @@ export const GET_ARTWORK = gql`
   }
 `;
 
+export const GET_GROUPS = gql`
+  query getGroups($userId: ID!) {
+    artwork(id: $userId) {
+      edges {
+        node {
+          pictures
+          title
+          description
+          tags
+          id
+          metrics {
+            totalVisits
+          }
+          rating
+        }
+      }
+    }
+  }
+`;
+
 export interface ArtworkQueryData {
   artwork: {
     edges: {
@@ -82,9 +102,10 @@ interface ArtworkCommentData {
 /**
  * Turns gql data into a list of comments and an image.
  */
-export function artCommentResolver(
-  data: ArtworkCommentData | undefined
-): { picture: string; comments: DiscussionComment[] } {
+export function artCommentResolver(data: ArtworkCommentData | undefined): {
+  picture: string;
+  comments: DiscussionComment[];
+} {
   const comments: DiscussionComment[] | undefined = !data
     ? []
     : data.artwork.edges?.[0].node.comments.edges.map(({ node }) => {

--- a/frontend/src/pages/Artwork/gql.ts
+++ b/frontend/src/pages/Artwork/gql.ts
@@ -58,19 +58,47 @@ export const GET_ARTWORK = gql`
 
 export const GET_GROUPS = gql`
   query getGroups($userId: ID!) {
-    artwork(id: $userId) {
+    users(id: $userId) {
       edges {
         node {
-          pictures
-          title
-          description
-          tags
-          id
-          metrics {
-            totalVisits
+          groups {
+            edges {
+              node {
+                name
+                id
+              }
+            }
           }
-          rating
         }
+      }
+    }
+  }
+`;
+
+interface GroupOption {
+  name: string;
+  id: string;
+}
+
+/**
+ * Reformats data to flat array of group options for adding artwork to group.
+ * @param data getGroups() GraphQL query result
+ * @returns Array of group options
+ */
+export function groupOptionsResolver(data: any): GroupOption[] {
+  return (
+    data?.users.edges?.[0].node.groups.edges.map((e: any) => ({
+      name: e.node.name,
+      id: e.node.id,
+    })) || []
+  );
+}
+
+export const ADD_ARTWORK_TO_GROUP = gql`
+  mutation addArtworkToGroup($artworkId: ID!, $groupId: ID!) {
+    updateGroup(groupData: { id: $groupId, artToAdd: $groupId }) {
+      group {
+        id
       }
     }
   }

--- a/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
+++ b/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
@@ -77,19 +77,18 @@ function GroupHub({ group }: GroupHubProps) {
   const { id } = useParams<{ id: string }>();
   const { goBack, push } = useHistory();
   const [leaveGroupMutation] = useMutation(LEAVE_GROUP);
-  const { profile: user} = useProfileInfo();
+  const { profile: user } = useProfileInfo();
 
   async function leaveGroup() {
     const payload = {
       user: user?.id,
-      group: id
-    }
-    let resp = await leaveGroupMutation({ variables: payload }); 
+      group: id,
+    };
+    let resp = await leaveGroupMutation({ variables: payload });
 
     if (resp["data"]["leaveGroup"]["success"]) {
       push("/groups");
-    }
-    else {
+    } else {
       alert("Error when attempting to leave group");
     }
   }
@@ -118,9 +117,6 @@ function GroupHub({ group }: GroupHubProps) {
         </div>
       </header>
       <div className="content">
-        <div className="actions">
-          <button onClick={leaveGroup}>Leave Group</button>
-        </div>
         <section>
           <h2>Group Bio</h2>
           <p>{group.bio}</p>
@@ -129,8 +125,9 @@ function GroupHub({ group }: GroupHubProps) {
           <h2 style={{ marginBottom: 0 }}>Activity</h2>
           <span className="entry-count">{group.artworks.length} entries</span>
           <div className="side-scroller">
-            {group.artworks.map((work) => (
+            {group.artworks.map((work, key) => (
               <ArtworkCard
+                key={key}
                 image={work.pictures[0]}
                 title={work.title}
                 onClick={() => push("/artwork/" + work.id)}
@@ -151,6 +148,14 @@ function GroupHub({ group }: GroupHubProps) {
               unit="Members"
               fallbackVal={0}
             />
+          </div>
+        </section>
+        <section>
+          <h2>Options</h2>
+          <div className="actions">
+            <button className="danger" onClick={leaveGroup}>
+              Leave Group
+            </button>
           </div>
         </section>
       </div>


### PR DESCRIPTION
Fixes #126 
Users can now add artworks to their groups on the `Artwork` page.

## Testing
1. Find an artwork that is in your personal portfolio which is not in the group portfolio. You can edit the initialization of your portfolio in `database.py` to include works that are not in your group's portfolio.
2. Click on the unique artwork in your personal portfolio.
3. On the Artwork page, scroll down and click on the group icon button with the blue background.
4. On the popup drawer, choose the group that does not have this artwork.
5. Go to the group and verify that the artwork was added.
6. Also test that adding an artwork that is already in the group portfolio does not create a duplicate.
## Other Changes
- Fixed the backend function that generates images. Previously picked up on files like `.DS_Store` which led to missing images on the frontend.
- Added an options section to the `GroupPage` and colored the "Leave Group" button red.
- Added general `Drawer` component that allows you to put content in a modal that slides up from the bottom of the screen.