### PR TITLE
Braden50/join groups

### DIFF
--- a/backend/mutations.py
+++ b/backend/mutations.py
@@ -279,10 +279,6 @@ class CheckMembershipMutation(graphene.Mutation):
     
     @staticmethod
     def checkMembership(user, group):
-        '''
-        Takes in a user object and group object
-        Returns true if user is a member of the group, false otherwise
-        '''
         if (user not in group.members) and (group not in user.groups):
             return False
         return True

--- a/backend/mutations.py
+++ b/backend/mutations.py
@@ -234,18 +234,6 @@ class DeleteGroupMutation(graphene.Mutation):  # ensure cascade
         return DeleteGroupMutation(success=success)
 
 
-class CheckMembershipMutation(graphene.Mutation):
-    ''' 
-    Returns true if user is a member of the group, false otherwise
-    Note: Membership is defined as the user being in the group's member list
-            AND the user contains the group in their group list
-    '''
-    member = graphene.Boolean()
-
-    class Arguments:
-        user_id = graphene.String()
-        group_id = graphene.String()
-
 class JoinGroupMutation(graphene.Mutation):
     """ Allows a specific user to join a specific group """
     success = graphene.Boolean()
@@ -291,6 +279,10 @@ class CheckMembershipMutation(graphene.Mutation):
     
     @staticmethod
     def checkMembership(user, group):
+        '''
+        Takes in a user object and group object
+        Returns true if user is a member of the group, false otherwise
+        '''
         if (user not in group.members) and (group not in user.groups):
             return False
         return True

--- a/backend/mutations.py
+++ b/backend/mutations.py
@@ -245,6 +245,12 @@ class JoinGroupMutation(graphene.Mutation):
     def mutate(self, info, user_id, group_id):
         group = UpdateGroupMutation.getGroup(group_id)
         user = UpdateUserMutation.getUser(user_id)
+        member = CheckMembershipMutation.checkMembership(
+            user = UpdateUserMutation.getUser(user_id),
+            group = UpdateGroupMutation.getGroup(group_id)
+        )
+        if member:
+            return JoinGroupMutation(success=False)
         expected_sizes = (len(group.members) + 1, len(user.groups) + 1)
         group.members.append(user)
         user.groups.append(group)
@@ -282,7 +288,7 @@ class CheckMembershipMutation(graphene.Mutation):
         return True
 
     def mutate(self, info, user_id, group_id):
-        member = checkMembership(
+        member = CheckMembershipMutation.checkMembership(
             user = UpdateUserMutation.getUser(user_id),
             group = UpdateGroupMutation.getGroup(group_id)
         )

--- a/backend/mutations.py
+++ b/backend/mutations.py
@@ -234,6 +234,18 @@ class DeleteGroupMutation(graphene.Mutation):  # ensure cascade
         return DeleteGroupMutation(success=success)
 
 
+class CheckMembershipMutation(graphene.Mutation):
+    ''' 
+    Returns true if user is a member of the group, false otherwise
+    Note: Membership is defined as the user being in the group's member list
+            AND the user contains the group in their group list
+    '''
+    member = graphene.Boolean()
+
+    class Arguments:
+        user_id = graphene.String()
+        group_id = graphene.String()
+
 class JoinGroupMutation(graphene.Mutation):
     """ Allows a specific user to join a specific group """
     success = graphene.Boolean()

--- a/backend/schema.py
+++ b/backend/schema.py
@@ -34,6 +34,7 @@ class Mutations(graphene.ObjectType):
     update_group = UpdateGroupMutation.Field()
     join_group = JoinGroupMutation.Field()
     leave_group = LeaveGroupMutation.Field()
+    check_membership = CheckMembershipMutation.Field()
 
     create_achievement = CreateAchievementMutation.Field()
 

--- a/backend/testing.py
+++ b/backend/testing.py
@@ -258,7 +258,7 @@ def create_groups(client, group_creators_with_members):
                     ) {{
                         success
                     }}
-                }}""".format(new_member[1], groups_with_ids[i][1],))
+                }}""".format(new_member[1], groups_with_ids[i][1]))
     return groups_with_ids
 
 

--- a/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
+++ b/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
@@ -96,8 +96,10 @@ function GroupHub({ group }: GroupHubProps) {
 
     if (resp["data"]["leaveGroup"]["success"]) {
       push("/groups");
-    } else {
+    }
+    else {
       alert("Error when attempting to leave group");
+      push("/groups");
     }
   }
 
@@ -114,7 +116,7 @@ function GroupHub({ group }: GroupHubProps) {
       };
       const memberResp = await checkMembershipMutation({ variables: payload });
       if (memberResp?.errors) {
-        console.log(memberResp.errors)
+        alert(memberResp.errors);
         push("/groups");
       }
       if (memberResp.data.checkMembership.member === true) {
@@ -125,14 +127,12 @@ function GroupHub({ group }: GroupHubProps) {
       // not a member
       const joinResp = await joinGroupMutation({ variables: payload });
       if (joinResp?.errors) {
-        alert('An error occurred')
-        console.log(memberResp.errors)
+        alert(memberResp.errors);
         push("/groups");
       }
       console.log(joinResp)
       if (joinResp.data.joinGroup.success === true) {
         setMember(true);
-        console.log(member);
         setLoading(false);
         return
       }
@@ -143,7 +143,7 @@ function GroupHub({ group }: GroupHubProps) {
     }
   }
   if (!member) {
-    checkMembership()
+    checkMembership();
   }
   if (loading) {
     return <Spinner absCenter={true} />;

--- a/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
+++ b/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
@@ -130,7 +130,6 @@ function GroupHub({ group }: GroupHubProps) {
       setLoading(false);
       return
     }
-  }
 
   useEffect(() => {
     setLoading(true);

--- a/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
+++ b/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
@@ -130,7 +130,6 @@ function GroupHub({ group }: GroupHubProps) {
         alert(memberResp.errors);
         push("/groups");
       }
-      console.log(joinResp)
       if (joinResp.data.joinGroup.success === true) {
         setMember(true);
         setLoading(false);
@@ -142,13 +141,14 @@ function GroupHub({ group }: GroupHubProps) {
       alert(error);
     }
   }
+
+
   if (!member) {
     checkMembership();
   }
   if (loading) {
     return <Spinner absCenter={true} />;
   }
-
 
   return (
     <article className="GroupPage">

--- a/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
+++ b/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
@@ -130,6 +130,24 @@ function GroupHub({ group }: GroupHubProps) {
       setLoading(false);
       return
     }
+    
+    //  Is a member of the group   
+    if (memberResp.data.checkMembership.member) { 
+      setLoading(false);        
+      return      
+    }
+    
+    // Is not a member and is joining
+    const joinResp = await joinGroupMutation({ variables: payload });
+    if (joinResp?.errors) {
+      alert(memberResp.errors);
+      push("/groups");
+    }
+    if (joinResp.data.joinGroup.success) {
+      setLoading(false);
+      return
+    }
+  }
 
   useEffect(() => {
     setLoading(true);

--- a/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
+++ b/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
@@ -109,28 +109,28 @@ function GroupHub({ group }: GroupHubProps) {
     const memberResp = await checkMembershipMutation({ variables: payload });    
       
     // If there is an error  
-      if (memberResp?.errors) {        
-        alert(memberResp.errors);        
-        push("/groups");      
-      }
-      
-      //  Is a member of the group   
-      if (memberResp.data.checkMembership.member) { 
-        setLoading(false);        
-        return      
-      }
-      
-      // Is not a member and is joining
-      const joinResp = await joinGroupMutation({ variables: payload });
-      if (joinResp?.errors) {
-        alert(memberResp.errors);
-        push("/groups");
-      }
-      if (joinResp.data.joinGroup.success) {
-        setLoading(false);
-        return
-      }
+    if (memberResp?.errors) {        
+      alert(memberResp.errors);        
+      push("/groups");      
     }
+    
+    //  Is a member of the group   
+    if (memberResp.data.checkMembership.member) { 
+      setLoading(false);        
+      return      
+    }
+    
+    // Is not a member and is joining
+    const joinResp = await joinGroupMutation({ variables: payload });
+    if (joinResp?.errors) {
+      alert(memberResp.errors);
+      push("/groups");
+    }
+    if (joinResp.data.joinGroup.success) {
+      setLoading(false);
+      return
+    }
+  }
 
   useEffect(() => {
     setLoading(true);

--- a/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
+++ b/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
@@ -5,6 +5,7 @@ import {
   GET_COMMENTS_QUERY,
   POST_DISCUSSION_MESSAGE,
   LEAVE_GROUP,
+  CHECK_MEMBERSHIP,
   groupResolver,
   groupCommentsResolver,
   Group,
@@ -13,7 +14,7 @@ import { ArrowLeft, MessageSquare, BookOpen } from "react-feather";
 import MetricBadge from "../../../components/MetricBadge/MetricBadge";
 import Spinner from "../../../components/Spinner/Spinner";
 import { Switch, useHistory, useParams } from "react-router-dom";
-import { useMemo } from "react";
+import { useMemo, useEffect, useState } from "react";
 import ConnectionErrorMessage from "../../../components/ConnectionErrorMessage/ConnectionErrorMessage.jsx";
 import { Route } from "react-router-dom";
 import Portfolio from "../../Portfolio/Portfolio";
@@ -77,7 +78,10 @@ function GroupHub({ group }: GroupHubProps) {
   const { id } = useParams<{ id: string }>();
   const { goBack, push } = useHistory();
   const [leaveGroupMutation] = useMutation(LEAVE_GROUP);
-  const { profile: user } = useProfileInfo();
+  const [checkMembershipMutation] = useMutation(CHECK_MEMBERSHIP);
+  const { profile: user} = useProfileInfo();
+  const [loading, setLoading] = useState(true)
+  const [member, setMember] = useState(null)
 
   async function leaveGroup() {
     const payload = {
@@ -92,6 +96,24 @@ function GroupHub({ group }: GroupHubProps) {
       alert("Error when attempting to leave group");
     }
   }
+
+  useEffect(async () => {
+    try {
+      setLoading(true)
+      const payload = {
+        user: user?.id,
+        group: id
+      }
+      const member = await checkMembershipMutation({ variables: payload });
+      
+      if (!member) {
+        try
+      }
+    }
+  })
+
+  if 
+
 
   return (
     <article className="GroupPage">

--- a/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
+++ b/frontend/src/pages/Groups/GroupPage/GroupPage.tsx
@@ -81,7 +81,7 @@ function GroupHub({ group }: GroupHubProps) {
   const [leaveGroupMutation] = useMutation(LEAVE_GROUP);
   const [joinGroupMutation] = useMutation(JOIN_GROUP);
   const [checkMembershipMutation] = useMutation(CHECK_MEMBERSHIP);
-  const { profile: user} = useProfileInfo();
+  const { profile: user } = useProfileInfo();
   const [loading, setLoading] = useState(true)
 
   async function leaveGroup() {
@@ -101,58 +101,41 @@ function GroupHub({ group }: GroupHubProps) {
     }
   }
 
-  async function checkMembership() {
+  useEffect(() => {
     const payload = {
       user: user?.id,
       group: id
     }
-    const memberResp = await checkMembershipMutation({ variables: payload });    
-      
-    // If there is an error  
-    if (memberResp?.errors) {        
-      alert(memberResp.errors);        
-      push("/groups");      
-    }
-    
-    //  Is a member of the group   
-    if (memberResp.data.checkMembership.member) { 
-      setLoading(false);        
-      return      
-    }
-    
-    // Is not a member and is joining
-    const joinResp = await joinGroupMutation({ variables: payload });
-    if (joinResp?.errors) {
-      alert(memberResp.errors);
-      push("/groups");
-    }
-    if (joinResp.data.joinGroup.success) {
-      setLoading(false);
-      return
-    }
-    
-    //  Is a member of the group   
-    if (memberResp.data.checkMembership.member) { 
-      setLoading(false);        
-      return      
-    }
-    
-    // Is not a member and is joining
-    const joinResp = await joinGroupMutation({ variables: payload });
-    if (joinResp?.errors) {
-      alert(memberResp.errors);
-      push("/groups");
-    }
-    if (joinResp.data.joinGroup.success) {
-      setLoading(false);
-      return
-    }
-  }
 
-  useEffect(() => {
+    async function checkMembership() {      
+      const memberResp = await checkMembershipMutation({ variables: payload });    
+        
+      // If there is an error  
+      if (memberResp?.errors) {        
+        alert(memberResp.errors);        
+        push("/groups");      
+      }
+      
+      //  Is a member of the group   
+      if (memberResp.data.checkMembership.member) { 
+        setLoading(false);        
+        return      
+      }
+      
+      // Is not a member and is joining
+      const joinResp = await joinGroupMutation({ variables: payload });
+      if (joinResp?.errors) {
+        alert(memberResp.errors);
+        push("/groups");
+      }
+      if (joinResp.data.joinGroup.success) {
+        setLoading(false);
+        return
+      }
+    }
     setLoading(true);
     checkMembership();
-  }, [])
+  }, [checkMembershipMutation, joinGroupMutation, push, id, user?.id])
 
   if (loading) {
     return <Spinner absCenter={true} />;

--- a/frontend/src/pages/Groups/GroupPage/gql.ts
+++ b/frontend/src/pages/Groups/GroupPage/gql.ts
@@ -75,11 +75,24 @@ export const LEAVE_GROUP = gql`
   }
 `;
 
+
+export const JOIN_GROUP = gql`
+  mutation join($user: String!, $group: String!) {
+    joinGroup(
+      userId: $user
+      groupId: $group
+    ) {
+      success
+    }
+  }
+`;
+
+
 export const CHECK_MEMBERSHIP = gql`
-  mutation checkMembership($user: String!, $group: String!) {
-    checkMember(
-      userId: $String!
-      groupId: $String!
+  mutation isMember($user: String!, $group: String!) {
+    checkMembership(
+      userId: $user
+      groupId: $group
     ) {
       member
     }

--- a/frontend/src/pages/Groups/GroupPage/gql.ts
+++ b/frontend/src/pages/Groups/GroupPage/gql.ts
@@ -75,6 +75,17 @@ export const LEAVE_GROUP = gql`
   }
 `;
 
+export const CHECK_MEMBERSHIP = gql`
+  mutation checkMembership($user: String!, $group: String!) {
+    checkMember(
+      userId: $String!
+      groupId: $String!
+    ) {
+      member
+    }
+  }
+`;
+
 export interface GqlGroupData {
   groups: {
     edges: {

--- a/frontend/src/pages/Groups/GroupPage/gql.ts
+++ b/frontend/src/pages/Groups/GroupPage/gql.ts
@@ -75,7 +75,6 @@ export const LEAVE_GROUP = gql`
   }
 `;
 
-<<<<<<< HEAD
 
 export const JOIN_GROUP = gql`
   mutation join($user: String!, $group: String!) {
@@ -94,13 +93,6 @@ export const CHECK_MEMBERSHIP = gql`
     checkMembership(
       userId: $user
       groupId: $group
-=======
-export const CHECK_MEMBERSHIP = gql`
-  mutation checkMembership($user: String!, $group: String!) {
-    checkMember(
-      userId: $String!
-      groupId: $String!
->>>>>>> 9af3800 (Added check membership mutation. Still need to add frontend functionality)
     ) {
       member
     }

--- a/frontend/src/pages/Groups/GroupPage/gql.ts
+++ b/frontend/src/pages/Groups/GroupPage/gql.ts
@@ -75,6 +75,7 @@ export const LEAVE_GROUP = gql`
   }
 `;
 
+<<<<<<< HEAD
 
 export const JOIN_GROUP = gql`
   mutation join($user: String!, $group: String!) {
@@ -93,6 +94,13 @@ export const CHECK_MEMBERSHIP = gql`
     checkMembership(
       userId: $user
       groupId: $group
+=======
+export const CHECK_MEMBERSHIP = gql`
+  mutation checkMembership($user: String!, $group: String!) {
+    checkMember(
+      userId: $String!
+      groupId: $String!
+>>>>>>> 9af3800 (Added check membership mutation. Still need to add frontend functionality)
     ) {
       member
     }

--- a/frontend/src/pages/Groups/GroupsList/GroupsList.jsx
+++ b/frontend/src/pages/Groups/GroupsList/GroupsList.jsx
@@ -83,6 +83,7 @@ function useGroupList() {
       })) || [],
     [data]
   );
+  console.log(groups);
   return { loading, groups };
 }
 

--- a/frontend/src/pages/Groups/GroupsList/GroupsList.jsx
+++ b/frontend/src/pages/Groups/GroupsList/GroupsList.jsx
@@ -83,7 +83,6 @@ function useGroupList() {
       })) || [],
     [data]
   );
-  console.log(groups);
   return { loading, groups };
 }
 


### PR DESCRIPTION
Solves #128

Added ability to join and leave groups comfortably. To join a group you must access its URL while signed in.

Only "issue" I could find after my own testing was that I would have to manually refresh the group list to see updates. I believe this is a cache issue we already know about though.


To test:

Boot up the app for local testing (just "-l" flag)
With any account, join and leave groups as much as you want.

Group link: http://localhost:3000/group/<groupId>

"id": "R3JvdXBUeXBlOldlc3QgQ29hc3QgQXJ0",
"name": "West Coast Art"

"id": "R3JvdXBUeXBlOkFsbCBBcnQgV2VsY29tZQ==",
"name": "All Art Welcome"]