### PR TITLE
Add Toasts to App

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "react-rating-stars-component": "^2.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.2",
+    "react-toastify": "^7.0.4",
     "react-webcam": "^5.2.3",
     "sass": "^1.32.8",
     "typescript": "^4.2.3",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,7 @@ import Login from "./pages/Login/Login";
 import { useEffect } from "react";
 import useProfileInfo from "./hooks/useProfileInfo";
 import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 function App() {
   function CameraPage() {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,6 +14,7 @@ import SignUp from "./pages/SignUp/SignUp";
 import Login from "./pages/Login/Login";
 import { useEffect } from "react";
 import useProfileInfo from "./hooks/useProfileInfo";
+import { ToastContainer } from "react-toastify";
 
 function App() {
   function CameraPage() {
@@ -67,6 +68,7 @@ function App() {
 
         {profile && <TabBar />}
       </Router>
+      <ToastContainer />
     </main>
   );
 }

--- a/frontend/src/pages/Artwork/Artwork.tsx
+++ b/frontend/src/pages/Artwork/Artwork.tsx
@@ -10,7 +10,6 @@ import {
   Camera as CamIcon,
 } from "react-feather";
 import { useQuery, useMutation } from "@apollo/client";
-import { toast } from "react-toastify";
 import ArtReview from "../ArtReview/ArtReview";
 import Discussion from "../Discussion/Discussion";
 import Camera from "../Camera/Camera";
@@ -97,10 +96,10 @@ export default function Artwork() {
             </button>
             <h1>{artwork.title}</h1>
             <div className="options">
-              <button className="wrapper" onClick={() => toast("Default options")}>  
+              <button className="wrapper">  
                 <Upload />
               </button>
-              <button className="wrapper" onClick={() => toast("Ooh, position overridden!", { position: "top-center", })}>
+              <button className="wrapper">
                 <Maximize2 />
               </button>
             </div>

--- a/frontend/src/pages/Artwork/Artwork.tsx
+++ b/frontend/src/pages/Artwork/Artwork.tsx
@@ -11,7 +11,6 @@ import {
 } from "react-feather";
 import { useQuery, useMutation } from "@apollo/client";
 import { toast } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
 import ArtReview from "../ArtReview/ArtReview";
 import Discussion from "../Discussion/Discussion";
 import Camera from "../Camera/Camera";

--- a/frontend/src/pages/Artwork/Artwork.tsx
+++ b/frontend/src/pages/Artwork/Artwork.tsx
@@ -10,7 +10,8 @@ import {
   Camera as CamIcon,
 } from "react-feather";
 import { useQuery, useMutation } from "@apollo/client";
-
+import { toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 import ArtReview from "../ArtReview/ArtReview";
 import Discussion from "../Discussion/Discussion";
 import Camera from "../Camera/Camera";
@@ -97,10 +98,10 @@ export default function Artwork() {
             </button>
             <h1>{artwork.title}</h1>
             <div className="options">
-              <button className="wrapper">
+              <button className="wrapper" onClick={() => toast("Default options")}>  
                 <Upload />
               </button>
-              <button className="wrapper">
+              <button className="wrapper" onClick={() => toast("Ooh, position overridden!", { position: "top-center", })}>
                 <Maximize2 />
               </button>
             </div>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3455,6 +3455,11 @@
     "strip-ansi" "^6.0.0"
     "wrap-ansi" "^6.2.0"
 
+"clsx@^1.1.1":
+  "integrity" "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+  "resolved" "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz"
+  "version" "1.1.1"
+
 "co@^4.6.0":
   "integrity" "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
   "resolved" "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
@@ -9417,7 +9422,7 @@
     "strip-ansi" "6.0.0"
     "text-table" "0.2.0"
 
-"react-dom@*", "react-dom@^16.11.0", "react-dom@^16.14.0", "react-dom@>=15.3.0", "react-dom@>=16.8 || ^17.0.0":
+"react-dom@*", "react-dom@^16.11.0", "react-dom@^16.14.0", "react-dom@>=15.3.0", "react-dom@>=16", "react-dom@>=16.8 || ^17.0.0":
   "integrity" "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw=="
   "resolved" "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz"
   "version" "16.14.0"
@@ -9570,12 +9575,19 @@
   optionalDependencies:
     "fsevents" "^2.1.3"
 
+"react-toastify@^7.0.4":
+  "integrity" "sha512-Rol7+Cn39hZp5hQ/k6CbMNE2CKYV9E5OQdC/hBLtIQU2xz7DdAm7xil4NITQTHR6zEbE5RVFbpgSwTD7xRGLeQ=="
+  "resolved" "https://registry.npmjs.org/react-toastify/-/react-toastify-7.0.4.tgz"
+  "version" "7.0.4"
+  dependencies:
+    "clsx" "^1.1.1"
+
 "react-webcam@^5.2.3":
   "integrity" "sha512-7rBh4Veeumpy45ObkZCsG6zezaamkwK5Iqxc0AFhX2ZzWQZXZ+f61yJ1yIb9Y62U4d7KkfP/xEduBCRzzcN4Dw=="
   "resolved" "https://registry.npmjs.org/react-webcam/-/react-webcam-5.2.3.tgz"
   "version" "5.2.3"
 
-"react@*", "react@^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0", "react@^16.11.0", "react@^16.14.0", "react@^16.8.0 || ^17", "react@^16.8.0 || ^17.0.0", "react@^16.8.6 || ^17", "react@>= 16", "react@>=15", "react@>=15.3.0", "react@>=16.8 || ^17.0.0":
+"react@*", "react@^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0", "react@^16.11.0", "react@^16.14.0", "react@^16.8.0 || ^17", "react@^16.8.0 || ^17.0.0", "react@^16.8.6 || ^17", "react@>= 16", "react@>=15", "react@>=15.3.0", "react@>=16", "react@>=16.8 || ^17.0.0":
   "integrity" "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g=="
   "resolved" "https://registry.npmjs.org/react/-/react-16.14.0.tgz"
   "version" "16.14.0"


### PR DESCRIPTION
## Summary
We can now use fancy Toasts to display notifications from anywhere in the app! Currently there is a default `ToastContainer` sitting at the top of our app, but if you want to override some of the options for a specific toast, you can pass it a JSON object with said options.

## Testing
Start up the frontend and backend, log in, and visit any artwork page. I have commandeered the upload and maximize buttons in the upper right corner for purpose of demonstration since they aren't currently being used. Check to make sure that you get appropriate toasts from clicking each button, one with default options and one that has been centered.

Fixes #135 