### PR TITLE
Braden50/more specific error catch

### DIFF
--- a/backend/mutations.py
+++ b/backend/mutations.py
@@ -361,9 +361,9 @@ class CreateUserMutation(graphene.Mutation):
         metrics = UserMetrics()
         try:
             user = User.objects.get(pk=user_data.email)
-            if user:
-                # user already exists with that email
-                return CreateUserMutation(user=None, success=False)
+            # If no query error, then either the user exists or
+            # user variable becomes None. In both cases the response fails.
+            return CreateUserMutation(user=None, success=False)
         except Exception as e:  # email not taken
             if "matching query does not exist" not in str(e):
                 # unexpected error during query

--- a/backend/mutations.py
+++ b/backend/mutations.py
@@ -355,12 +355,19 @@ class CreateUserMutation(graphene.Mutation):
         user_data = UserInput(required=True)
 
     def mutate(self, info, user_data=None):
+        # NOTE: Netlify creates the account regardless of this response
         portfolio = Portfolio()
         settings = Settings()
         metrics = UserMetrics()
         try:
             user = User.objects.get(pk=user_data.email)
+            if user:
+                # user already exists with that email
+                return CreateUserMutation(user=None, success=False)
         except Exception as e:  # email not taken
+            if "matching query does not exist" not in str(e):
+                # unexpected error during query
+                return CreateUserMutation(user=None, success=False)
             user = User(
                 name=user_data.name,
                 bio=user_data.bio,


### PR DESCRIPTION
Fixes #134 by manually checking the error response for a non-existent query error. 

There do seem to be ways of catching specific GraphQL errors as objects, but the process seems quite tedious from my initial research (eg https://github.com/graphql-python/graphene-django/issues/1072)

Small PR. It is not perfect, but I think this makes the logic more reliable.